### PR TITLE
Improve error messages

### DIFF
--- a/src/XlsWorkSheet.h
+++ b/src/XlsWorkSheet.h
@@ -6,6 +6,7 @@
 #include "XlsWorkBook.h"
 #include "CellType.h"
 #include "utils.h"
+#include <string>
 
 class XlsWorkSheet {
   xls::xlsWorkSheet* pWS_;
@@ -18,9 +19,12 @@ public:
   XlsWorkSheet(const XlsWorkBook& wb, int i) {
     offset_ = dateOffset(wb.workbook()->is1904);
 
-    if (i < 0 || i >= wb.nSheets())
-      Rcpp::stop("Invalid sheet index");
-
+    if (i < 0 || i >= wb.nSheets()) {
+      std::string message;
+      message = Rcpp::sprintf<80>( "Invalid sheet index.  Should be in [0, %d]", wb.nSheets() );
+      Rcpp::stop(message.c_str());
+    }
+    
     pWS_ = xls_getWorkSheet(wb.workbook(), i);
     if (pWS_ == NULL)
       Rcpp::stop("Failed open sheet");
@@ -89,9 +93,13 @@ public:
 
   Rcpp::List readCols(Rcpp::CharacterVector names, std::vector<CellType> types,
                       std::string na, int nskip = 0) {
-    if ((int) names.size() != ncol_ || (int) types.size() != ncol_)
-      Rcpp::stop("Need one name and type for each column");
-
+    if ((int) names.size() != ncol_ || (int) types.size() != ncol_) {
+      std::string message;
+      message = Rcpp::sprintf<100>("Recieved %d names and %d types but worksheet contains %d columns.", 
+                                  names.size(), types.size(),  ncol_);
+      Rcpp::stop(message.c_str());
+    } 
+    
     Rcpp::List cols(ncol_);
 
     // Initialise columns

--- a/src/XlsWorkSheet.h
+++ b/src/XlsWorkSheet.h
@@ -20,9 +20,7 @@ public:
     offset_ = dateOffset(wb.workbook()->is1904);
 
     if (i < 0 || i >= wb.nSheets()) {
-      std::string message;
-      message = Rcpp::sprintf<80>( "Invalid sheet index.  Should be in [0, %d]", wb.nSheets() );
-      Rcpp::stop(message.c_str());
+      Rcpp::stop(Rcpp::sprintf<80>( "Invalid sheet index.  Should be in [0, %d]", wb.nSheets() ).c_str());
     }
     
     pWS_ = xls_getWorkSheet(wb.workbook(), i);
@@ -94,10 +92,8 @@ public:
   Rcpp::List readCols(Rcpp::CharacterVector names, std::vector<CellType> types,
                       std::string na, int nskip = 0) {
     if ((int) names.size() != ncol_ || (int) types.size() != ncol_) {
-      std::string message;
-      message = Rcpp::sprintf<100>("Recieved %d names and %d types but worksheet contains %d columns.", 
-                                  names.size(), types.size(),  ncol_);
-      Rcpp::stop(message.c_str());
+      Rcpp::stop(Rcpp::sprintf<100>("Recieved %d names and %d types but worksheet contains %d columns.", 
+				    names.size(), types.size(),  ncol_).c_str());
     } 
     
     Rcpp::List cols(ncol_);

--- a/src/XlsxWorkSheet.h
+++ b/src/XlsxWorkSheet.h
@@ -120,10 +120,8 @@ public:
                       const std::vector<CellType>& types,
                       const std::string& na, int nskip = 0) {
     if ((int) names.size() != ncol_ || (int) types.size() != ncol_) { 
-      std::string message;
-      message = Rcpp::sprintf<100>("Recieved %d names and %d types but worksheet contains %d columns.", 
-                                  names.size(), types.size(),  ncol_);
-      Rcpp::stop(message.c_str());
+      Rcpp::stop(Rcpp::sprintf<100>("Recieved %d names and %d types but worksheet contains %d columns.", 
+				    names.size(), types.size(),  ncol_).c_str());
     } 
     
     // Initialise columns

--- a/src/XlsxWorkSheet.h
+++ b/src/XlsxWorkSheet.h
@@ -5,6 +5,7 @@
 #include "rapidxml.h"
 #include "XlsxWorkBook.h"
 #include "XlsxCell.h"
+#include <string>
 
 // Key reference for understanding the structure of the XML is
 // ECMA-376 (http://www.ecma-international.org/publications/standards/Ecma-376.htm)
@@ -118,9 +119,13 @@ public:
   Rcpp::List readCols(Rcpp::CharacterVector names,
                       const std::vector<CellType>& types,
                       const std::string& na, int nskip = 0) {
-    if ((int) names.size() != ncol_ || (int) types.size() != ncol_)
-      Rcpp::stop("Need one name and type for each column");
-
+    if ((int) names.size() != ncol_ || (int) types.size() != ncol_) { 
+      std::string message;
+      message = Rcpp::sprintf<100>("Recieved %d names and %d types but worksheet contains %d columns.", 
+                                  names.size(), types.size(),  ncol_);
+      Rcpp::stop(message.c_str());
+    } 
+    
     // Initialise columns
     int n = nrow_ - nskip;
     Rcpp::List cols(ncol_);


### PR DESCRIPTION
to provide more information.
- For read_xlx, when the requested worksheets doesn't exist.
- For read_xlx, and read_xlsx, when the number of column names or types doesn't match the file.
