### PR TITLE
Assume all linux flavors have asprintf

### DIFF
--- a/src/unix/config.h
+++ b/src/unix/config.h
@@ -2,7 +2,7 @@
 /* config.h.in.  Generated from configure.in by autoheader.  */
 
 /* Define to 1 if you have the `asprintf' function. */
-#if defined(_GNU_SOURCE) || defined(_DEFAULT_SOURCE) || defined(__APPLE__) || defined(__sun)
+#if defined(_GNU_SOURCE) || defined(_DEFAULT_SOURCE) || defined(__APPLE__) || defined(__sun) || defined(__gnu_linux__)
 #define HAVE_ASPRINTF 1
 #endif
 


### PR DESCRIPTION
Fixes #189 and doesn't seem to have negative impacts on other platforms (I used r-hub to test Debian, Fedora, Ubuntu, CentOS and Windows).

It seems like we might be able to delete the if statement altogether, but this change seemed less likely to cause problems.