### PR TITLE
Selective col type guessing; add CELL_UNKNOWN, COL_UNKNOWN

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # readxl 0.1.1.9000
 
+* Selective column type guessing: `col_types` now accepts `"guess"` to allow user to specify some column types, while allowing others to be guessed (#286 @jennybc)
+
 * Numeric data that appears in a `"date"` column is coerced to a date. Also throws a warning. (#277, #266 @jennybc)
 
 * Dates that appear in a numeric column are converted to `NA` instead of their integer representation. Also throws warning. (#277, #263 @jennybc)

--- a/R/read_excel.R
+++ b/R/read_excel.R
@@ -12,13 +12,13 @@ NULL
 #'   provides `col_types` as a vector, `col_names` can have one entry per
 #'   column, i.e. have the same length as `col_types`, or one entry per
 #'   unskipped column.
-#' @param col_types Either `NULL` to guess from the spreadsheet or a character
-#'   vector containing one entry per column from these options: "skip",
-#'   "logical", "numeric", "date", "text" or "list". The content of a cell in a
-#'   skipped column is never read and that column will not appear in the data
-#'   frame output. A list cell loads a column as a list of length 1 vectors,
-#'   which are typed using the type guessing logic from `col_types = NULL`, but
-#'   on a cell-by-cell basis.
+#' @param col_types Either `NULL` to guess all from the spreadsheet or a
+#'   character vector containing one entry per column from these options:
+#'   "skip", "guess", "logical", "numeric", "date", "text" or "list". The
+#'   content of a cell in a skipped column is never read and that column will
+#'   not appear in the data frame output. A list cell loads a column as a list
+#'   of length 1 vectors, which are typed using the type guessing logic from
+#'   `col_types = NULL`, but on a cell-by-cell basis.
 #' @param na Character vector of strings to use for missing values. By default,
 #'   readxl treats blank cells as missing data.
 #' @param skip Number of rows to skip before reading any data. Leading blank
@@ -35,6 +35,12 @@ NULL
 #'
 #' # Skipping rows and using default column names
 #' read_excel(datasets, skip = 148, col_names = FALSE)
+#'
+#' # if col_types is of length one, it will be recycled
+#' read_excel(datasets, col_types = "text")
+#'
+#' # you can specify some col_types and guess others
+#' read_excel(datasets, col_types = c("text", "guess", "numeric", "guess", "guess"))
 #'
 #' # "list" col_type can handle information of disparate types
 #' df <- read_excel(readxl_example("clippy.xlsx"), col_types = c("text", "list"))
@@ -141,7 +147,7 @@ standardise_sheet <- function(sheet, sheet_names) {
 
 check_col_types <- function(col_types) {
   if (is.null(col_types)) {
-    return(col_types)
+    return("guess")
   }
   stopifnot(is.character(col_types), length(col_types) > 0, !anyNA(col_types))
 
@@ -151,7 +157,8 @@ check_col_types <- function(col_types) {
     col_types[blank] <- "skip"
   }
 
-  accepted_types <- c("skip", "logical", "numeric", "date", "text", "list")
+  accepted_types <-
+    c("skip", "guess", "logical", "numeric", "date", "text", "list")
   ok <- col_types %in% accepted_types
   if (any(!ok)) {
     info <- paste(

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -83,7 +83,8 @@
 <h1 class="hasAnchor">
 <a href="#readxl-0-1-1-9000" class="anchor"> </a>readxl 0.1.1.9000</h1>
 <ul>
-<li><p>Dates that appear in a numeric column are converted to <code>NA</code> instead of their integer representation. Also throws warning. (#277, #263, @jennybc)</p></li>
+<li><p>Numeric data that appears in a <code>"date"</code> column is coerced to a date. Also throws a warning. (#277, #266 @jennybc)</p></li>
+<li><p>Dates that appear in a numeric column are converted to <code>NA</code> instead of their integer representation. Also throws warning. (#277, #263 @jennybc)</p></li>
 <li><p>“Number stored as text”: when a text cell is found in a <code>"numeric"</code> column, <code><a href="../reference/read_excel.html">read_excel()</a></code> attempts to coerce the string to numeric and falls back to <code>NA</code> if unsuccessful. Also throws warning. (#277, #217, #106 @jennybc)</p></li>
 <li><p>Cells in error are treated as blank and are imported as <code>NA</code> (instead of the string <code>"error"</code>). (#277, #62 @jennybc)</p></li>
 <li><p>Dates that arise from a formula are now treated as dates (vs. numeric) in xls. (#277 @jennybc)</p></li>

--- a/docs/reference/read_excel.html
+++ b/docs/reference/read_excel.html
@@ -108,13 +108,13 @@ provides <code>col_types</code> as a vector, <code>col_names</code> can have one
 column, i.e. have the same length as <code>col_types</code>, or one entry per
 unskipped column.</dd>
       <dt>col_types</dt>
-      <dd>Either <code>NULL</code> to guess from the spreadsheet or a character
-vector containing one entry per column from these options: &quot;skip&quot;,
-&quot;logical&quot;, &quot;numeric&quot;, &quot;date&quot;, &quot;text&quot; or &quot;list&quot;. The content of a cell in a
-skipped column is never read and that column will not appear in the data
-frame output. A list cell loads a column as a list of length 1 vectors,
-which are typed using the type guessing logic from <code>col_types = NULL</code>, but
-on a cell-by-cell basis.</dd>
+      <dd>Either <code>NULL</code> to guess all from the spreadsheet or a
+character vector containing one entry per column from these options:
+&quot;skip&quot;, &quot;guess&quot;, &quot;logical&quot;, &quot;numeric&quot;, &quot;date&quot;, &quot;text&quot; or &quot;list&quot;. The
+content of a cell in a skipped column is never read and that column will
+not appear in the data frame output. A list cell loads a column as a list
+of length 1 vectors, which are typed using the type guessing logic from
+<code>col_types = NULL</code>, but on a cell-by-cell basis.</dd>
       <dt>na</dt>
       <dd>Character vector of strings to use for missing values. By default,
 readxl treats blank cells as missing data.</dd>
@@ -156,6 +156,22 @@ rows are automatically skipped.</dd>
 #&gt; 1   6.5   3.0   5.2   2.0 virginica
 #&gt; 2   6.2   3.4   5.4   2.3 virginica
 #&gt; 3   5.9   3.0   5.1   1.8 virginica</div><div class='input'>
+<span class='co'># if col_types is of length one, it will be recycled</span>
+<span class='fu'>read_excel</span>(<span class='no'>datasets</span>, <span class='kw'>col_types</span> <span class='kw'>=</span> <span class='st'>"text"</span>)</div><div class='output co'>#&gt; # A tibble: 150 × 5
+#&gt;   Sepal.Length Sepal.Width Petal.Length Petal.Width Species
+#&gt;          &lt;chr&gt;       &lt;chr&gt;        &lt;chr&gt;       &lt;chr&gt;   &lt;chr&gt;
+#&gt; 1          5.1         3.5          1.4         0.2  setosa
+#&gt; 2          4.9           3          1.4         0.2  setosa
+#&gt; 3          4.7         3.2          1.3         0.2  setosa
+#&gt; # ... with 147 more rows</div><div class='input'>
+<span class='co'># you can specify some col_types and guess others</span>
+<span class='fu'>read_excel</span>(<span class='no'>datasets</span>, <span class='kw'>col_types</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"text"</span>, <span class='st'>"guess"</span>, <span class='st'>"numeric"</span>, <span class='st'>"guess"</span>, <span class='st'>"guess"</span>))</div><div class='output co'>#&gt; # A tibble: 150 × 5
+#&gt;   Sepal.Length Sepal.Width Petal.Length Petal.Width Species
+#&gt;          &lt;chr&gt;       &lt;dbl&gt;        &lt;dbl&gt;       &lt;dbl&gt;   &lt;chr&gt;
+#&gt; 1          5.1         3.5          1.4         0.2  setosa
+#&gt; 2          4.9         3.0          1.4         0.2  setosa
+#&gt; 3          4.7         3.2          1.3         0.2  setosa
+#&gt; # ... with 147 more rows</div><div class='input'>
 <span class='co'># "list" col_type can handle information of disparate types</span>
 <span class='no'>df</span> <span class='kw'>&lt;-</span> <span class='fu'>read_excel</span>(<span class='fu'><a href='readxl_example.html'>readxl_example</a></span>(<span class='st'>"clippy.xlsx"</span>), <span class='kw'>col_types</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"text"</span>, <span class='st'>"list"</span>))
 <span class='no'>df</span></div><div class='output co'>#&gt; # A tibble: 4 × 2

--- a/man/read_excel.Rd
+++ b/man/read_excel.Rd
@@ -27,13 +27,13 @@ provides \code{col_types} as a vector, \code{col_names} can have one entry per
 column, i.e. have the same length as \code{col_types}, or one entry per
 unskipped column.}
 
-\item{col_types}{Either \code{NULL} to guess from the spreadsheet or a character
-vector containing one entry per column from these options: "skip",
-"logical", "numeric", "date", "text" or "list". The content of a cell in a
-skipped column is never read and that column will not appear in the data
-frame output. A list cell loads a column as a list of length 1 vectors,
-which are typed using the type guessing logic from \code{col_types = NULL}, but
-on a cell-by-cell basis.}
+\item{col_types}{Either \code{NULL} to guess all from the spreadsheet or a
+character vector containing one entry per column from these options:
+"skip", "guess", "logical", "numeric", "date", "text" or "list". The
+content of a cell in a skipped column is never read and that column will
+not appear in the data frame output. A list cell loads a column as a list
+of length 1 vectors, which are typed using the type guessing logic from
+\code{col_types = NULL}, but on a cell-by-cell basis.}
 
 \item{na}{Character vector of strings to use for missing values. By default,
 readxl treats blank cells as missing data.}
@@ -60,6 +60,12 @@ read_excel(datasets, "mtcars")
 
 # Skipping rows and using default column names
 read_excel(datasets, skip = 148, col_names = FALSE)
+
+# if col_types is of length one, it will be recycled
+read_excel(datasets, col_types = "text")
+
+# you can specify some col_types and guess others
+read_excel(datasets, col_types = c("text", "guess", "numeric", "guess", "guess"))
 
 # "list" col_type can handle information of disparate types
 df <- read_excel(readxl_example("clippy.xlsx"), col_types = c("text", "list"))

--- a/src/XlsxCell.h
+++ b/src/XlsxCell.h
@@ -165,6 +165,7 @@ public:
 
     switch(type) {
 
+    case CELL_UNKNOWN:
     case CELL_BLANK:
       return "NA";
 

--- a/src/XlsxWorkSheet.cpp
+++ b/src/XlsxWorkSheet.cpp
@@ -24,7 +24,9 @@ CharacterVector xlsx_col_types(std::string path, int sheet_i = 0,
                                bool has_col_names = false) {
 
   XlsxWorkSheet ws(path, sheet_i, skip);
-  std::vector<ColType> types = ws.colTypes(na, guess_max, has_col_names);
+  std::vector<ColType> types(ws.ncol());
+  std::fill(types.begin(), types.end(), COL_UNKNOWN);
+  types = ws.colTypes(types, na, guess_max, has_col_names);
   return colTypeDescs(types);
 }
 
@@ -63,21 +65,17 @@ List read_xlsx_(std::string path, int sheet_i, RObject col_names,
   }
 
   // Get column types --------------------------------------------------
-  std::vector<ColType> colTypes;
-  switch(TYPEOF(col_types)) {
-  case NILSXP:
-    colTypes = ws.colTypes(na, guess_max, has_col_names);
-    break;
-  case STRSXP:
-    colTypes = colTypeStrings(as<CharacterVector>(col_types));
-    colTypes = recycleTypes(colTypes, ws.ncol());
-    break;
-  default:
-    Rcpp::stop("`col_types` must be a character vector or NULL");
+  if (TYPEOF(col_types) != STRSXP) {
+    Rcpp::stop("`col_types` must be a character vector");
   }
+  std::vector<ColType> colTypes = colTypeStrings(as<CharacterVector>(col_types));
+  colTypes = recycleTypes(colTypes, ws.ncol());
   if ((int) colTypes.size() != ws.ncol()) {
     Rcpp::stop("Sheet %d has %d columns, but `col_types` has length %d.",
                sheet_i + 1, ws.ncol(), colTypes.size());
+  }
+  if (requiresGuess(colTypes)) {
+    colTypes = ws.colTypes(colTypes, na, guess_max, has_col_names);
   }
   colTypes = finalizeTypes(colTypes);
   colNames = reconcileNames(colNames, colTypes, sheet_i);

--- a/src/XlsxWorkSheet.h
+++ b/src/XlsxWorkSheet.h
@@ -84,11 +84,10 @@ public:
     return out;
   }
 
-  std::vector<ColType> colTypes(const StringSet& na,
+  std::vector<ColType> colTypes(std::vector<ColType> types,
+                                const StringSet& na,
                                 int guess_max = 1000,
                                 bool has_col_names = false) {
-    std::vector<ColType> types(ncol_);
-
     std::vector<XlsxCell>::const_iterator xcell;
     xcell = has_col_names ? secondRow_ : firstRow_;
 
@@ -98,19 +97,27 @@ public:
       return types;
     }
 
+    std::vector<bool> type_known(types.size());
+    for (size_t j = 0; j < types.size(); j++) {
+      type_known[j] = types[j] != COL_UNKNOWN;
+    }
+
     // base is row the data starts on **in the spreadsheet**
     int base = firstRow_->row() + has_col_names;
     while (xcell != cells_.end() && xcell->row() - base < guess_max) {
       if ((xcell->row() - base + 1) % 1000 == 0) {
         Rcpp::checkUserInterrupt();
       }
-      if (xcell->col() < ncol_) {
-        ColType type = as_ColType(
-          xcell->type(na, wb_.stringTable(), wb_.dateStyles())
-        );
-        if (type > types[xcell->col()]) {
-          types[xcell->col()] = type;
-        }
+      int j = xcell->col();
+      if (type_known[j] || j >= ncol_) {
+        xcell++;
+        continue;
+      }
+      ColType type = as_ColType(
+        xcell->type(na, wb_.stringTable(), wb_.dateStyles())
+      );
+      if (type > types[j]) {
+        types[j] = type;
       }
       xcell++;
     }
@@ -158,12 +165,14 @@ public:
       // Needs to compare to actual cell type to give warnings
       switch(types[j]) {
 
+      case COL_UNKNOWN:
       case COL_BLANK:
       case COL_SKIP:
         break;
 
       case COL_LOGICAL:
         switch(type) {
+        case CELL_UNKNOWN:
         case CELL_BLANK:
           LOGICAL(col)[row] = NA_LOGICAL;
           break;
@@ -196,6 +205,7 @@ public:
 
       case COL_DATE:
         switch(type) {
+        case CELL_UNKNOWN:
         case CELL_BLANK:
           REAL(col)[row] = NA_REAL;
           break;
@@ -223,6 +233,7 @@ public:
 
       case COL_NUMERIC:
         switch(type) {
+        case CELL_UNKNOWN:
         case CELL_BLANK:
           REAL(col)[row] = NA_REAL;
           break;
@@ -264,6 +275,7 @@ public:
         // not issuing warnings for NAs or coercion, because "text" is the
         // fallback column type and there are too many warnings to be helpful
         switch(type) {
+        case CELL_UNKNOWN:
         case CELL_BLANK:
           SET_STRING_ELT(col, row, NA_STRING);
           break;
@@ -289,6 +301,7 @@ public:
 
       case COL_LIST:
         switch(type) {
+        case CELL_UNKNOWN:
         case CELL_BLANK: {
           SET_VECTOR_ELT(col, row, Rf_ScalarLogical(NA_LOGICAL));
           break;

--- a/tests/testthat/test-col-types.R
+++ b/tests/testthat/test-col-types.R
@@ -70,6 +70,20 @@ test_that("types guessed correctly [xls]", {
   expect_true(all(vapply(types, function(x) is.na(x[3]), logical(1))))
 })
 
+test_that("we can specify some col_types and guess others", {
+  ctypes <- c("numeric", "text", "guess", "guess", "text", "guess")
+  exp_cls <- c("numeric", "character", "logical",
+               "POSIXct", "character", "character")
+
+  df <- read_excel(test_sheet("types.xlsx"), col_types = ctypes)
+  cls <- vapply(df, function(x) class(x)[1], character(1))
+  expect_equivalent(cls, exp_cls)
+
+  df <- read_excel(test_sheet("types.xls"), col_types = ctypes)
+  cls <- vapply(df, function(x) class(x)[1], character(1))
+  expect_equivalent(cls, exp_cls)
+})
+
 test_that("guess_max is honored for col_types", {
   expect_warning(
     types <- read_excel(


### PR DESCRIPTION
Relates to a "nice to have" mentioned in https://github.com/tidyverse/readxl/issues/198#issuecomment-280669414.

The underlying motivation was to add CELL_UNKNOWN to facilitate on-demand cell-typing (discussed in #285). But then you have to add COL_UNKNOWN to keep the enums happy. And at that point, you might as well exploit it and let people specify some col types and guess others.

I'm going to close #285 and start that effort over, after this gets reviewed and merged.