### PR TITLE
Use uint32_t to index into xls string table; fixes #129

### DIFF
--- a/src/libxls/xlstool.h
+++ b/src/libxls/xlstool.h
@@ -48,6 +48,6 @@ extern void xls_showCell(struct st_cell_data* cell);
 extern void xls_showFont(struct st_font_data* font);
 extern void xls_showXF(XF8* xf);
 extern void xls_showFormat(struct st_format_data* format);
-extern BYTE* xls_getfcell(xlsWorkBook* pWB,struct st_cell_data* cell,WORD *label);
+extern BYTE* xls_getfcell(xlsWorkBook* pWB,struct st_cell_data* cell,DWORD *label);
 extern char* xls_getCSS(xlsWorkBook* pWB);
 extern void xls_showBOF(BOF* bof);

--- a/src/xls.c
+++ b/src/xls.c
@@ -530,7 +530,7 @@ struct st_cell_data *xls_addCell(xlsWorkSheet* pWS,BOF* bof,BYTE* buf)
         break;
     case XLS_RECORD_LABELSST:
     case XLS_RECORD_LABEL:
-		cell->str=xls_getfcell(pWS->workbook,cell,(WORD_UA *)&((LABEL*)buf)->value);
+		cell->str=xls_getfcell(pWS->workbook,cell,(DWORD_UA *)&((LABEL*)buf)->value);
 		sscanf((char *)cell->str, "%d", &cell->l);
 		sscanf((char *)cell->str, "%lf", &cell->d);
 		break;

--- a/src/xlstool.c
+++ b/src/xlstool.c
@@ -626,7 +626,7 @@ void xls_showXF(XF8* xf)
     printf("GroundColor: 0x%x\n",xf->groundcolor);
 }
 
-BYTE *xls_getfcell(xlsWorkBook* pWB,struct st_cell_data* cell,WORD *label)
+BYTE *xls_getfcell(xlsWorkBook* pWB,struct st_cell_data* cell,DWORD *label)
 {
     struct st_xf_data *xf;
 	WORD	len;
@@ -638,7 +638,7 @@ BYTE *xls_getfcell(xlsWorkBook* pWB,struct st_cell_data* cell,WORD *label)
     {
     case XLS_RECORD_LABELSST:
 		//printf("WORD: %u short: %u str: %s\n", *label, xlsShortVal(*label), pWB->sst.string[xlsShortVal(*label)].str );
-        asprintf(&ret,"%s",pWB->sst.string[xlsShortVal(*label)].str);
+        asprintf(&ret,"%s",pWB->sst.string[xlsIntVal(*label)].str);
         break;
     case XLS_RECORD_BLANK:
     case XLS_RECORD_MULBLANK:


### PR DESCRIPTION
libxls clearly anticipates that the string table size might require an unsigned 32 bit integer, e.g.:

https://github.com/tidyverse/readxl/blob/0587f00dcc889bc263b232da4c1951c631b975f3/src/libxls/xlsstruct.h#L240-L246

https://github.com/tidyverse/readxl/blob/0587f00dcc889bc263b232da4c1951c631b975f3/src/libxls/xlsstruct.h#L398-L412

https://github.com/tidyverse/readxl/blob/0587f00dcc889bc263b232da4c1951c631b975f3/src/xls.c#L137

https://github.com/tidyverse/readxl/blob/0587f00dcc889bc263b232da4c1951c631b975f3/src/xls.c#L152

(all these types are defined [here](https://github.com/tidyverse/readxl/blob/0587f00dcc889bc263b232da4c1951c631b975f3/src/libxls/xlstypes.h#L39-L47))

But then it was indexing into the table with a 16 bit integer and therefore vulnerable to getting the wrong strings. It takes a large sheet to expose this, i.e. more than 65535 unique strings. Which is the case with the xls from #129.

Two questions:

  * Should I add a test for this? It would require a very large xls, plus it doesn't really seem like something readxl should be responsible for.
  * Should I try to push this change back into libxls? It's not trivial for me, because it's on sourceforge and uses svn, whereas I've only done this with Git/GitHub. Yet it's a tiny change and seems like a no-brainer.

