### PR TITLE
Refactor and align date format handling

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -5,6 +5,10 @@ xls_sheets <- function(path) {
     .Call('readxl_xls_sheets', PACKAGE = 'readxl', path)
 }
 
+xls_date_formats <- function(path) {
+    .Call('readxl_xls_date_formats', PACKAGE = 'readxl', path)
+}
+
 xls_col_names <- function(path, na, sheet_i = 0L, skip = 0L) {
     .Call('readxl_xls_col_names', PACKAGE = 'readxl', path, na, sheet_i, skip)
 }
@@ -25,8 +29,8 @@ xlsx_strings <- function(path) {
     .Call('readxl_xlsx_strings', PACKAGE = 'readxl', path)
 }
 
-xlsx_date_styles <- function(path) {
-    .Call('readxl_xlsx_date_styles', PACKAGE = 'readxl', path)
+xlsx_date_formats <- function(path) {
+    .Call('readxl_xlsx_date_formats', PACKAGE = 'readxl', path)
 }
 
 xlsx_dim <- function(path, sheet_i = 0L, skip = 0L) {

--- a/src/ColSpec.h
+++ b/src/ColSpec.h
@@ -103,8 +103,7 @@ bool inline requiresGuess(std::vector<ColType> types) {
 
 bool inline isDateTime(int id, const std::set<int> custom) {
   // Page and section numbers below refer to
-  // ECMA-376
-  // version, date, and download URL given in XlsxCell.h
+  // ECMA-376 (version, date, and download URL given in XlsxCell.h)
   //
   // Example from L.2.7.4.4 p4698 for hypothetical cell D2
   // Cell D2 contains the text "Q1" and is defined in the cell table of sheet1

--- a/src/ColSpec.h
+++ b/src/ColSpec.h
@@ -102,9 +102,31 @@ bool inline requiresGuess(std::vector<ColType> types) {
 }
 
 bool inline isDateTime(int id, const std::set<int> custom) {
-  // Date formats:
-  // ECMA-376 (http://www.ecma-international.org/publications/standards/Ecma-376.htm)
-  // 18.8.30 numFmt (Number Format)  (p1777)
+  // Page and section numbers below refer to
+  // ECMA-376
+  // version, date, and download URL given in XlsxCell.h
+  //
+  // Example from L.2.7.4.4 p4698 for hypothetical cell D2
+  // Cell D2 contains the text "Q1" and is defined in the cell table of sheet1
+  // as:
+  //
+  // <c r="D2" s="7" t="s">
+  //     <v>0</v>
+  // </c>
+  //
+  // On this cell, the attribute value s="7" indicates that the 7th (zero-based)
+  // <xf> definition of <cellXfs> holds the formatting information for the cell.
+  // The 7th <xf> of <cellXfs> is defined as:
+  //
+  // <xf numFmtId="0" fontId="4" fillId="2" borderId="2" xfId="1" applyBorder="1"/>
+  //
+  // The number formatting information cannot be found in a <numFmt> definition
+  // because it is a built-in format; instead, it is implicitly understood to be
+  // the 0th built-in number format.
+  //
+  // This function stores knowledge about these built-in number formats.
+  //
+  // 18.8.30 numFmt (Number Format) p1786
   // Date times: 14-22, 27-36, 45-47, 50-58, 71-81 (inclusive)
   if ((id >= 14 && id <= 22) ||
       (id >= 27 && id <= 36) ||
@@ -121,6 +143,14 @@ bool inline isDateTime(int id, const std::set<int> custom) {
 }
 
 inline bool isDateFormat(std::string x) {
+  // TO FIX? So far no bug reports due to this.
+  // Logic below is too simple. For example, it deems this format string a date:
+  // "$"#,##0_);[Red]\("$"#,##0\)
+  // because of the `d` in `[Red]`
+  //
+  // Ideally this can wait until we are using something like
+  // https://github.com/WizardMac/TimeFormatStrings
+  // which presumably offers fancier ways to analyze format codes.
   for (size_t i = 0; i < x.size(); ++i) {
     switch (x[i]) {
     case 'd':

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -16,6 +16,17 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// xls_date_formats
+std::set<int> xls_date_formats(std::string path);
+RcppExport SEXP readxl_xls_date_formats(SEXP pathSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< std::string >::type path(pathSEXP);
+    rcpp_result_gen = Rcpp::wrap(xls_date_formats(path));
+    return rcpp_result_gen;
+END_RCPP
+}
 // xls_col_names
 CharacterVector xls_col_names(std::string path, std::vector<std::string> na, int sheet_i, int skip);
 RcppExport SEXP readxl_xls_col_names(SEXP pathSEXP, SEXP naSEXP, SEXP sheet_iSEXP, SEXP skipSEXP) {
@@ -85,14 +96,14 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// xlsx_date_styles
-std::set<int> xlsx_date_styles(std::string path);
-RcppExport SEXP readxl_xlsx_date_styles(SEXP pathSEXP) {
+// xlsx_date_formats
+std::set<int> xlsx_date_formats(std::string path);
+RcppExport SEXP readxl_xlsx_date_formats(SEXP pathSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< std::string >::type path(pathSEXP);
-    rcpp_result_gen = Rcpp::wrap(xlsx_date_styles(path));
+    rcpp_result_gen = Rcpp::wrap(xlsx_date_formats(path));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/src/XlsCell.h
+++ b/src/XlsCell.h
@@ -41,8 +41,7 @@ public:
   }
 
   void inferType(const StringSet& na,
-                 const xls::st_xf* styles,
-                 const std::set<int>& dateStyles) {
+                 const std::set<int>& dateFormats) {
     // 1. Review of Excel's declared cell types, then
     // 2. Summary of how Excel's cell types map to our CellType enum
     //
@@ -124,12 +123,8 @@ public:
           ct = CELL_BLANK;
           break;
         }
-        if (styles == NULL) {
-          ct = CELL_NUMERIC;
-          break;
-        }
-        int format = styles->xf[cell_->xf].format;
-        ct = isDateTime(format, dateStyles) ? CELL_DATE : CELL_NUMERIC;
+        int format = cell_->xf;
+        ct = (dateFormats.count(format) > 0) ? CELL_DATE : CELL_NUMERIC;
         break;
       } else { // formula evaluates to Boolean, string, or error
 
@@ -178,12 +173,8 @@ public:
           ct = CELL_BLANK;
           break;
         }
-        if (styles == NULL) {
-          ct = CELL_NUMERIC;
-          break;
-        }
-        int format = styles->xf[cell_->xf].format;
-        ct = isDateTime(format, dateStyles) ? CELL_DATE : CELL_NUMERIC;
+        int format = cell_->xf;
+        ct = (dateFormats.count(format) > 0) ? CELL_DATE : CELL_NUMERIC;
       }
       break;
 

--- a/src/XlsWorkBook.cpp
+++ b/src/XlsWorkBook.cpp
@@ -1,10 +1,14 @@
 #include <Rcpp.h>
 #include "XlsWorkBook.h"
-#include "XlsWorkSheet.h"
 using namespace Rcpp;
 
 // [[Rcpp::export]]
 CharacterVector xls_sheets(std::string path) {
   XlsWorkBook wb(path);
   return wb.sheets();
+}
+
+// [[Rcpp::export]]
+std::set<int> xls_date_formats(std::string path) {
+  return XlsWorkBook(path).dateFormats();
 }

--- a/src/XlsWorkBook.h
+++ b/src/XlsWorkBook.h
@@ -17,7 +17,7 @@ class XlsWorkBook {
   // common to Xls[x]WorkBook
   std::string path_;
   bool is1904_;
-  std::set<int> dateStyles_;
+  std::set<int> dateFormats_;
 
   // kept as data + accessor in XlsWorkBook vs. member function in XlsxWorkBook
   int n_sheets_;
@@ -40,15 +40,7 @@ public:
     }
 
     is1904_ = pWB_->is1904;
-
-    int n_formats = pWB_->formats.count;
-    for (int i = 0; i < n_formats; ++i) {
-      xls::st_format::st_format_data format = pWB_->formats.format[i];
-      std::string value((char*) format.value);
-      if (isDateFormat(value)) {
-        dateStyles_.insert(format.index);
-      }
-    }
+    cacheDateFormats(pWB_);
 
     xls::xls_close_WB(pWB_);
   }
@@ -69,8 +61,46 @@ public:
     return is1904_;
   }
 
-  const std::set<int>& dateStyles() const {
-    return dateStyles_;
+  const std::set<int>& dateFormats() const {
+    return dateFormats_;
+  }
+
+private:
+
+  void cacheDateFormats(xls::xlsWorkBook* pWB) {
+
+    // Figure out which custom formats are dates
+    // [MS-XLS] 2.4.126 Format p301
+    std::set<int> customDateFormats;
+    int n_formats = pWB->formats.count;
+    if (n_formats > 0) {
+      for (int i = 0; i < n_formats; ++i) {
+        const xls::st_format::st_format_data format = pWB->formats.format[i];
+        // format.value = format string
+        // in xlsx, this is formatCode
+        std::string code((char*) format.value);
+        if (isDateFormat(code)) {
+          // format.index = identifier used by other records
+          // in xlsx, this is numFormatId
+          customDateFormats.insert(format.index);
+        }
+      }
+    }
+
+    // Cache 0-based indices of the XF records that refer to a
+    // number format that is a date format
+    int n_xfs = pWB->xfs.count;
+    if (n_xfs == 0) {
+      return;
+    }
+
+    for (int i = 0; i < n_xfs; ++i) {
+      const xls::st_xf::st_xf_data xf = pWB->xfs.xf[i];
+      int formatId = xf.format;
+      if (isDateTime(formatId, customDateFormats)) {
+        dateFormats_.insert(i);
+      }
+    }
   }
 
 };

--- a/src/XlsWorkSheet.h
+++ b/src/XlsWorkSheet.h
@@ -8,9 +8,14 @@
 #include "ColSpec.h"
 
 class XlsWorkSheet {
+  // the host workbook
   XlsWorkBook wb_;
+
+  // xls specifics
   xls::xlsWorkBook* pWB_;
   xls::xlsWorkSheet* pWS_;
+
+  // common to xls[x]
   std::set<int> dateFormats_;
   std::vector<XlsCell> cells_;
   std::string sheetName_;

--- a/src/XlsWorkSheet.h
+++ b/src/XlsWorkSheet.h
@@ -11,7 +11,7 @@ class XlsWorkSheet {
   XlsWorkBook wb_;
   xls::xlsWorkBook* pWB_;
   xls::xlsWorkSheet* pWS_;
-  std::set<int> dateStyles_;
+  std::set<int> dateFormats_;
   std::vector<XlsCell> cells_;
   std::string sheetName_;
   int ncol_, nrow_;
@@ -36,7 +36,7 @@ public:
                  sheetName_, sheet_i + 1);
     }
     xls_parseWorkSheet(pWS_);
-    dateStyles_ = wb.dateStyles();
+    dateFormats_ = wb.dateFormats();
 
     loadCells();
     parseGeometry(skip);
@@ -66,7 +66,7 @@ public:
       if (xcell->col() >= ncol_) {
         break;
       }
-      xcell->inferType(na, &pWS_->workbook->xfs, dateStyles_);
+      xcell->inferType(na, dateFormats_);
       out[xcell->col()] = xcell->asCharSxp();
       xcell++;
     }
@@ -102,7 +102,7 @@ public:
         xcell++;
         continue;
       }
-      xcell->inferType(na, &pWS_->workbook->xfs, dateStyles_);
+      xcell->inferType(na, dateFormats_);
       ColType type = as_ColType(xcell->type());
       if (type > types[j]) {
         types[j] = type;
@@ -146,7 +146,7 @@ public:
         continue;
       }
 
-      xcell->inferType(na, &pWS_->workbook->xfs, dateStyles_);
+      xcell->inferType(na, dateFormats_);
       CellType type = xcell->type();
       Rcpp::RObject col = cols[j];
       // row to write into

--- a/src/XlsxCell.h
+++ b/src/XlsxCell.h
@@ -9,10 +9,10 @@
 
 // Key reference for understanding the structure of the XML is
 // ECMA-376 (http://www.ecma-international.org/publications/standards/Ecma-376.htm)
-// Section and page numbers below refer to the 4th edition
-// 18.3.1.4   c           (Cell)       [p1598]
-// 18.3.1.96  v           (Cell Value) [p1709]
-// 18.18.11   ST_CellType (Cell Type)  [p2443]
+// Section and page numbers below refer to the 5th edition October 2016
+// 18.3.1.4   c           (Cell)       [p1593]
+// 18.3.1.96  v           (Cell Value) [p1707]
+// 18.18.11   ST_CellType (Cell Type)  [p2451]
 
 class XlsxCell {
   rapidxml::xml_node<>* cell_;
@@ -48,12 +48,12 @@ public:
 
   void inferType(const StringSet& na,
                  const std::vector<std::string>& stringTable,
-                 const std::set<int>& dateStyles) {
+                 const std::set<int>& dateFormats) {
     // 1. Review of Excel's declared cell types, then
     // 2. Summary of how Excel's cell types map to our CellType enum
     //
     // this table refers to the value of the t attribute of a cell
-    // 18.18.11   ST_CellType (Cell Type)  [p2443]
+    // 18.18.11   ST_CellType (Cell Type)  [p2451]
     // This simple type is restricted to the values listed in the following table:
     // -------------------------------------------------------------------------
     // Enumeration Value          Description
@@ -84,11 +84,11 @@ public:
     //   Boolean cell and its value (TRUE or FALSE) is not in na
     //
     // CELL_DATE
-    //   numeric cell (t attr is "n" or does not exist) with a date style
+    //   numeric cell (t attr is "n" or does not exist) with a date format
     //
     // CELL_NUMERIC
-    //   numeric cell (t attr is "n" or does not exist) with no style or a
-    //   non-date style
+    //   numeric cell (t attr is "n" or does not exist) with no format or a
+    //   non-date format
     //
     // CELL_TEXT
     //   inlineStr cell and string is found and string is not na
@@ -128,8 +128,8 @@ public:
     // n (Number)                 Cell containing a number.
     if (t == NULL || strncmp(t->value(), "n", 5) == 0) {
       rapidxml::xml_attribute<>* s = cell_->first_attribute("s");
-      int style = (s == NULL) ? -1 : atoi(s->value());
-      type_ = (dateStyles.count(style) > 0) ? CELL_DATE : CELL_NUMERIC;
+      int format = (s == NULL) ? -1 : atoi(s->value());
+      type_ = (dateFormats.count(format) > 0) ? CELL_DATE : CELL_NUMERIC;
       return;
     }
 

--- a/src/XlsxWorkBook.cpp
+++ b/src/XlsxWorkBook.cpp
@@ -13,6 +13,6 @@ std::vector<std::string> xlsx_strings(std::string path) {
 }
 
 // [[Rcpp::export]]
-std::set<int> xlsx_date_styles(std::string path) {
-  return XlsxWorkBook(path).dateStyles();
+std::set<int> xlsx_date_formats(std::string path) {
+  return XlsxWorkBook(path).dateFormats();
 }

--- a/src/XlsxWorkSheet.h
+++ b/src/XlsxWorkSheet.h
@@ -7,13 +7,13 @@
 #include "XlsxCell.h"
 #include "ColSpec.h"
 
-// Key reference for understanding the structure of the XML is
-// ECMA-376 (http://www.ecma-international.org/publications/standards/Ecma-376.htm)
-// Section and page numbers below refer to the 4th edition
-// 18.3.1.73  row         (Row)        [p1677]
-// 18.3.1.4   c           (Cell)       [p1598]
-// 18.3.1.96  v           (Cell Value) [p1709]
-// 18.18.11   ST_CellType (Cell Type)  [p2443]
+// Page and section numbers below refer to
+// ECMA-376
+// version, date, and download URL given in XlsxCell.h
+// 18.3.1.73  row         (Row)        [p1685]
+// 18.3.1.4   c           (Cell)       [p1593]
+// 18.3.1.96  v           (Cell Value) [p1707]
+// 18.18.11   ST_CellType (Cell Type)  [p2451]
 
 class XlsxWorkSheet {
   XlsxWorkBook wb_;
@@ -78,7 +78,7 @@ public:
       if (xcell->col() >= ncol_) {
         break;
       }
-      xcell->inferType(na, wb_.stringTable(), wb_.dateStyles());
+      xcell->inferType(na, wb_.stringTable(), wb_.dateFormats());
       out[xcell->col()] = xcell->asCharSxp(wb_.stringTable());
       xcell++;
     }
@@ -114,7 +114,7 @@ public:
         xcell++;
         continue;
       }
-      xcell->inferType(na, wb_.stringTable(), wb_.dateStyles());
+      xcell->inferType(na, wb_.stringTable(), wb_.dateFormats());
       ColType type = as_ColType(xcell->type());
       if (type > types[j]) {
         types[j] = type;
@@ -158,7 +158,7 @@ public:
         continue;
       }
 
-      xcell->inferType(na, wb_.stringTable(), wb_.dateStyles());
+      xcell->inferType(na, wb_.stringTable(), wb_.dateFormats());
       CellType type = xcell->type();
       Rcpp::RObject col = cols[j];
       // row to write into

--- a/src/utils.h
+++ b/src/utils.h
@@ -21,13 +21,13 @@
 // ECMA-376
 // version, date, and download URL given in XlsxCell.h
 //
-// 18.2.28 workbookPr (Workbook Properties) p1582
+// 18.2.28 workbookPr (Workbook Properties) p1586
 // in xl/workbook.xml, node workbook, child node workbookPr
 // attribute date1904:
 // 0 or false --> 1900 date system
 // 1 or true --> 1904 date system (this is the default)
 //
-// 18.17.4.1 p2067 holds definition of the date systems
+// 18.17.4.1 p2073 holds definition of the date systems
 //
 // Date systems ---------------------------------------------------------------
 // 1900 system: first possible date is 1900-01-01 00:00:00,
@@ -61,7 +61,7 @@ inline double dateRound(double dttm) {
 // Otherwise: do nothing
 inline double POSIXctFromSerial(double xlDate, bool is1904) {
   if (!is1904 && xlDate < 61) {
-    xlDate = (xlDate < 60) ? ++xlDate : -1;
+    xlDate = (xlDate < 60) ? xlDate + 1 : -1;
   }
   if (xlDate < 0) {
     Rcpp::warning("NA inserted for impossible 1900-02-29 datetime");


### PR DESCRIPTION
Main point is to prepare for greater unification of xls and xlsx processing (#284).

This makes the date format handling on the xls side match that from xlsx as closely as possible.

Since I had to read all the docs on numeric/date formatting, I made some other superficial changes:

  * "style(s)" --> "format(s)". Because that's really what we mean and using that vocabulary makes it less confusing to read the docs.
  * Updated my beloved copy of ECMA-376 Part 1 to the 5th edition and (hopefully) all the associated page numbers.
  * Moved some more notes into comments for future re-orientation.