### PR TITLE
Accept sheet parsed from `range`; closes #318

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -79,13 +79,14 @@ read_excel(xlsx_example, sheet = "chickwts")
 read_excel(xls_example, sheet = 4)
 ```
 
-There are various ways to control which cells are read.
+There are various ways to control which cells are read. You can even specify the sheet here, if providing an Excel-style cell range.
 
 ```{r}
 read_excel(xlsx_example, n_max = 3)
-read_excel(xls_example, range = "C1:E4")
-read_excel(xls_example, range = cell_rows(1:4))
-read_excel(xls_example, range = cell_cols("B:D"))
+read_excel(xlsx_example, range = "C1:E4")
+read_excel(xlsx_example, range = cell_rows(1:4))
+read_excel(xlsx_example, range = cell_cols("B:D"))
+read_excel(xlsx_example, range = "mtcars!B1:D5")
 ```
 
 If `NA`s are represented by something other than blank cells, set the `na` argument.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ read_excel(xls_example, sheet = 4)
 #> # ... with 997 more rows
 ```
 
-There are various ways to control which cells are read.
+There are various ways to control which cells are read. You can even specify the sheet here, if providing an Excel-style cell range.
 
 ``` r
 read_excel(xlsx_example, n_max = 3)
@@ -105,21 +105,21 @@ read_excel(xlsx_example, n_max = 3)
 #> 1          5.1         3.5          1.4         0.2  setosa
 #> 2          4.9         3.0          1.4         0.2  setosa
 #> 3          4.7         3.2          1.3         0.2  setosa
-read_excel(xls_example, range = "C1:E4")
+read_excel(xlsx_example, range = "C1:E4")
 #> # A tibble: 3 × 3
 #>   Petal.Length Petal.Width Species
 #>          <dbl>       <dbl>   <chr>
 #> 1          1.4         0.2  setosa
 #> 2          1.4         0.2  setosa
 #> 3          1.3         0.2  setosa
-read_excel(xls_example, range = cell_rows(1:4))
+read_excel(xlsx_example, range = cell_rows(1:4))
 #> # A tibble: 3 × 5
 #>   Sepal.Length Sepal.Width Petal.Length Petal.Width Species
 #>          <dbl>       <dbl>        <dbl>       <dbl>   <chr>
 #> 1          5.1         3.5          1.4         0.2  setosa
 #> 2          4.9         3.0          1.4         0.2  setosa
 #> 3          4.7         3.2          1.3         0.2  setosa
-read_excel(xls_example, range = cell_cols("B:D"))
+read_excel(xlsx_example, range = cell_cols("B:D"))
 #> # A tibble: 150 × 3
 #>   Sepal.Width Petal.Length Petal.Width
 #>         <dbl>        <dbl>       <dbl>
@@ -127,6 +127,14 @@ read_excel(xls_example, range = cell_cols("B:D"))
 #> 2         3.0          1.4         0.2
 #> 3         3.2          1.3         0.2
 #> # ... with 147 more rows
+read_excel(xlsx_example, range = "mtcars!B1:D5")
+#> # A tibble: 4 × 3
+#>     cyl  disp    hp
+#>   <dbl> <dbl> <dbl>
+#> 1     6   160   110
+#> 2     6   160   110
+#> 3     4   108    93
+#> # ... with 1 more rows
 ```
 
 If `NA`s are represented by something other than blank cells, set the `na` argument.

--- a/docs/index.html
+++ b/docs/index.html
@@ -125,7 +125,7 @@ xls_example &lt;-<span class="st"> </span><span class="kw"><a href="reference/re
 <span class="co">#&gt; 2 -20.62 181.03   650   4.2       15</span>
 <span class="co">#&gt; 3 -26.00 184.10    42   5.4       43</span>
 <span class="co">#&gt; # ... with 997 more rows</span></code></pre></div>
-<p>There are various ways to control which cells are read.</p>
+<p>There are various ways to control which cells are read. You can even specify the sheet here, if providing an Excel-style cell range.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw"><a href="reference/read_excel.html">read_excel</a></span>(xlsx_example, <span class="dt">n_max =</span> <span class="dv">3</span>)
 <span class="co">#&gt; # A tibble: 3 × 5</span>
 <span class="co">#&gt;   Sepal.Length Sepal.Width Petal.Length Petal.Width Species</span>
@@ -133,28 +133,36 @@ xls_example &lt;-<span class="st"> </span><span class="kw"><a href="reference/re
 <span class="co">#&gt; 1          5.1         3.5          1.4         0.2  setosa</span>
 <span class="co">#&gt; 2          4.9         3.0          1.4         0.2  setosa</span>
 <span class="co">#&gt; 3          4.7         3.2          1.3         0.2  setosa</span>
-<span class="kw"><a href="reference/read_excel.html">read_excel</a></span>(xls_example, <span class="dt">range =</span> <span class="st">"C1:E4"</span>)
+<span class="kw"><a href="reference/read_excel.html">read_excel</a></span>(xlsx_example, <span class="dt">range =</span> <span class="st">"C1:E4"</span>)
 <span class="co">#&gt; # A tibble: 3 × 3</span>
 <span class="co">#&gt;   Petal.Length Petal.Width Species</span>
 <span class="co">#&gt;          &lt;dbl&gt;       &lt;dbl&gt;   &lt;chr&gt;</span>
 <span class="co">#&gt; 1          1.4         0.2  setosa</span>
 <span class="co">#&gt; 2          1.4         0.2  setosa</span>
 <span class="co">#&gt; 3          1.3         0.2  setosa</span>
-<span class="kw"><a href="reference/read_excel.html">read_excel</a></span>(xls_example, <span class="dt">range =</span> <span class="kw"><a href="reference/cell-specification.html">cell_rows</a></span>(<span class="dv">1</span>:<span class="dv">4</span>))
+<span class="kw"><a href="reference/read_excel.html">read_excel</a></span>(xlsx_example, <span class="dt">range =</span> <span class="kw"><a href="reference/cell-specification.html">cell_rows</a></span>(<span class="dv">1</span>:<span class="dv">4</span>))
 <span class="co">#&gt; # A tibble: 3 × 5</span>
 <span class="co">#&gt;   Sepal.Length Sepal.Width Petal.Length Petal.Width Species</span>
 <span class="co">#&gt;          &lt;dbl&gt;       &lt;dbl&gt;        &lt;dbl&gt;       &lt;dbl&gt;   &lt;chr&gt;</span>
 <span class="co">#&gt; 1          5.1         3.5          1.4         0.2  setosa</span>
 <span class="co">#&gt; 2          4.9         3.0          1.4         0.2  setosa</span>
 <span class="co">#&gt; 3          4.7         3.2          1.3         0.2  setosa</span>
-<span class="kw"><a href="reference/read_excel.html">read_excel</a></span>(xls_example, <span class="dt">range =</span> <span class="kw"><a href="reference/cell-specification.html">cell_cols</a></span>(<span class="st">"B:D"</span>))
+<span class="kw"><a href="reference/read_excel.html">read_excel</a></span>(xlsx_example, <span class="dt">range =</span> <span class="kw"><a href="reference/cell-specification.html">cell_cols</a></span>(<span class="st">"B:D"</span>))
 <span class="co">#&gt; # A tibble: 150 × 3</span>
 <span class="co">#&gt;   Sepal.Width Petal.Length Petal.Width</span>
 <span class="co">#&gt;         &lt;dbl&gt;        &lt;dbl&gt;       &lt;dbl&gt;</span>
 <span class="co">#&gt; 1         3.5          1.4         0.2</span>
 <span class="co">#&gt; 2         3.0          1.4         0.2</span>
 <span class="co">#&gt; 3         3.2          1.3         0.2</span>
-<span class="co">#&gt; # ... with 147 more rows</span></code></pre></div>
+<span class="co">#&gt; # ... with 147 more rows</span>
+<span class="kw"><a href="reference/read_excel.html">read_excel</a></span>(xlsx_example, <span class="dt">range =</span> <span class="st">"mtcars!B1:D5"</span>)
+<span class="co">#&gt; # A tibble: 4 × 3</span>
+<span class="co">#&gt;     cyl  disp    hp</span>
+<span class="co">#&gt;   &lt;dbl&gt; &lt;dbl&gt; &lt;dbl&gt;</span>
+<span class="co">#&gt; 1     6   160   110</span>
+<span class="co">#&gt; 2     6   160   110</span>
+<span class="co">#&gt; 3     4   108    93</span>
+<span class="co">#&gt; # ... with 1 more rows</span></code></pre></div>
 <p>If <code>NA</code>s are represented by something other than blank cells, set the <code>na</code> argument.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw"><a href="reference/read_excel.html">read_excel</a></span>(xlsx_example, <span class="dt">na =</span> <span class="st">"setosa"</span>)
 <span class="co">#&gt; # A tibble: 150 × 5</span>

--- a/docs/reference/read_excel.html
+++ b/docs/reference/read_excel.html
@@ -84,15 +84,15 @@ extension, <code>read_xls()</code> and <code>read_xlsx()</code> can be used to
 read files without extension.</p>
     
 
-    <pre><span class='fu'>read_excel</span>(<span class='no'>path</span>, <span class='kw'>sheet</span> <span class='kw'>=</span> <span class='fl'>1L</span>, <span class='kw'>range</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>col_names</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>,
+    <pre><span class='fu'>read_excel</span>(<span class='no'>path</span>, <span class='kw'>sheet</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>range</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>col_names</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>,
   <span class='kw'>col_types</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>na</span> <span class='kw'>=</span> <span class='st'>""</span>, <span class='kw'>skip</span> <span class='kw'>=</span> <span class='fl'>0</span>, <span class='kw'>n_max</span> <span class='kw'>=</span> <span class='fl'>Inf</span>,
   <span class='kw'>guess_max</span> <span class='kw'>=</span> <span class='fu'>min</span>(<span class='fl'>1000</span>, <span class='no'>n_max</span>))
 
-<span class='fu'>read_xls</span>(<span class='no'>path</span>, <span class='kw'>sheet</span> <span class='kw'>=</span> <span class='fl'>1L</span>, <span class='kw'>range</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>col_names</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>,
+<span class='fu'>read_xls</span>(<span class='no'>path</span>, <span class='kw'>sheet</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>range</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>col_names</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>,
   <span class='kw'>col_types</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>na</span> <span class='kw'>=</span> <span class='st'>""</span>, <span class='kw'>skip</span> <span class='kw'>=</span> <span class='fl'>0</span>, <span class='kw'>n_max</span> <span class='kw'>=</span> <span class='fl'>Inf</span>,
   <span class='kw'>guess_max</span> <span class='kw'>=</span> <span class='fu'>min</span>(<span class='fl'>1000</span>, <span class='no'>n_max</span>))
 
-<span class='fu'>read_xlsx</span>(<span class='no'>path</span>, <span class='kw'>sheet</span> <span class='kw'>=</span> <span class='fl'>1L</span>, <span class='kw'>range</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>col_names</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>,
+<span class='fu'>read_xlsx</span>(<span class='no'>path</span>, <span class='kw'>sheet</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>range</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>col_names</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>,
   <span class='kw'>col_types</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>na</span> <span class='kw'>=</span> <span class='st'>""</span>, <span class='kw'>skip</span> <span class='kw'>=</span> <span class='fl'>0</span>, <span class='kw'>n_max</span> <span class='kw'>=</span> <span class='fl'>Inf</span>,
   <span class='kw'>guess_max</span> <span class='kw'>=</span> <span class='fu'>min</span>(<span class='fl'>1000</span>, <span class='no'>n_max</span>))</pre>
     
@@ -106,14 +106,17 @@ read files without extension.</p>
     <tr>
       <th>sheet</th>
       <td><p>Sheet to read. Either a string (the name of a sheet), or an
-integer (the position of the sheet). Defaults to the first sheet.</p></td>
+integer (the position of the sheet). Ignored if the sheet is specified via
+<code>range</code>. If neither argument specifies the sheet, defaults to the first
+sheet.</p></td>
     </tr>
     <tr>
       <th>range</th>
       <td><p>A cell range to read from, as described in <a href='cell-specification.html'>cell-specification</a>.
-Includes typical Excel ranges like "B3:D87" and more. Interpreted strictly,
-even if the range includes leading or trailing empty rows or columns. Takes
-precedence over <code>skip</code> and <code>n_max</code>.</p></td>
+Includes typical Excel ranges like "B3:D87", possibly including the sheet
+name like "Budget!B2:G14", and more. Interpreted strictly, even if the
+range forces the inclusion of leading or trailing empty rows or columns.
+Takes precedence over <code>skip</code>, <code>n_max</code> and <code>sheet</code>.</p></td>
     </tr>
     <tr>
       <th>col_names</th>
@@ -300,6 +303,14 @@ types.</p></td>
 #&gt;   Sepal.Width Petal.Length Petal.Width Species
 #&gt;         &lt;dbl&gt;        &lt;dbl&gt;       &lt;dbl&gt;   &lt;chr&gt;
 #&gt; 1         3.5          1.4         0.2  setosa</div><div class='input'>
+<span class='co'># Specify the sheet as part of the range</span>
+<span class='fu'>read_excel</span>(<span class='no'>datasets</span>, <span class='kw'>range</span> <span class='kw'>=</span> <span class='st'>"mtcars!B1:D5"</span>)</div><div class='output co'>#&gt; # A tibble: 4 × 3
+#&gt;     cyl  disp    hp
+#&gt;   &lt;dbl&gt; &lt;dbl&gt; &lt;dbl&gt;
+#&gt; 1     6   160   110
+#&gt; 2     6   160   110
+#&gt; 3     4   108    93
+#&gt; 4     6   258   110</div><div class='input'>
 <span class='co'># Read only specific rows or columns</span>
 <span class='fu'>read_excel</span>(<span class='no'>datasets</span>, <span class='kw'>range</span> <span class='kw'>=</span> <span class='fu'><a href='cell-specification.html'>cell_rows</a></span>(<span class='fl'>102</span>:<span class='fl'>151</span>), <span class='kw'>col_names</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>)</div><div class='output co'>#&gt; # A tibble: 50 × 5
 #&gt;     X__1  X__2  X__3  X__4      X__5

--- a/docs/reference/readxl_example.html
+++ b/docs/reference/readxl_example.html
@@ -95,8 +95,8 @@ directory. This function make them easy to access.</p>
     
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
-    <pre class="examples"><div class='input'><span class='fu'>readxl_example</span>()</div><div class='output co'>#&gt; [1] "clippy.xls"    "clippy.xlsx"   "datasets.xls"  "datasets.xlsx"
-#&gt; [5] "geometry.xls"  "geometry.xlsx"</div><div class='input'><span class='fu'>readxl_example</span>(<span class='st'>"datasets.xlsx"</span>)</div><div class='output co'>#&gt; [1] "/Users/jenny/rrr/readxl/inst/extdata/datasets.xlsx"</div></pre>
+    <pre class="examples"><div class='input'><span class='fu'>readxl_example</span>()</div><div class='output co'>#&gt; [1] "~$datasets.xlsx" "clippy.xls"      "clippy.xlsx"     "datasets.xls"   
+#&gt; [5] "datasets.xlsx"   "geometry.xls"    "geometry.xlsx"  </div><div class='input'><span class='fu'>readxl_example</span>(<span class='st'>"datasets.xlsx"</span>)</div><div class='output co'>#&gt; [1] "/Users/jenny/rrr/readxl/inst/extdata/datasets.xlsx"</div></pre>
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
     <h2>Contents</h2>

--- a/man/read_excel.Rd
+++ b/man/read_excel.Rd
@@ -6,15 +6,15 @@
 \alias{read_xlsx}
 \title{Read xls and xlsx files.}
 \usage{
-read_excel(path, sheet = 1L, range = NULL, col_names = TRUE,
+read_excel(path, sheet = NULL, range = NULL, col_names = TRUE,
   col_types = NULL, na = "", skip = 0, n_max = Inf,
   guess_max = min(1000, n_max))
 
-read_xls(path, sheet = 1L, range = NULL, col_names = TRUE,
+read_xls(path, sheet = NULL, range = NULL, col_names = TRUE,
   col_types = NULL, na = "", skip = 0, n_max = Inf,
   guess_max = min(1000, n_max))
 
-read_xlsx(path, sheet = 1L, range = NULL, col_names = TRUE,
+read_xlsx(path, sheet = NULL, range = NULL, col_names = TRUE,
   col_types = NULL, na = "", skip = 0, n_max = Inf,
   guess_max = min(1000, n_max))
 }
@@ -22,12 +22,15 @@ read_xlsx(path, sheet = 1L, range = NULL, col_names = TRUE,
 \item{path}{Path to the xls/xlsx file}
 
 \item{sheet}{Sheet to read. Either a string (the name of a sheet), or an
-integer (the position of the sheet). Defaults to the first sheet.}
+integer (the position of the sheet). Ignored if the sheet is specified via
+\code{range}. If neither argument specifies the sheet, defaults to the first
+sheet.}
 
 \item{range}{A cell range to read from, as described in \link{cell-specification}.
-Includes typical Excel ranges like "B3:D87" and more. Interpreted strictly,
-even if the range includes leading or trailing empty rows or columns. Takes
-precedence over \code{skip} and \code{n_max}.}
+Includes typical Excel ranges like "B3:D87", possibly including the sheet
+name like "Budget!B2:G14", and more. Interpreted strictly, even if the
+range forces the inclusion of leading or trailing empty rows or columns.
+Takes precedence over \code{skip}, \code{n_max} and \code{sheet}.}
 
 \item{col_names}{\code{TRUE} to use the first row as column names, \code{FALSE} to get
 default names, or a character vector giving a name for each column. If user
@@ -97,6 +100,9 @@ read_excel(datasets, n_max = 3)
 # Read from an Excel range using A1 or R1C1 notation
 read_excel(datasets, range = "C1:E7")
 read_excel(datasets, range = "R1C2:R2C5")
+
+# Specify the sheet as part of the range
+read_excel(datasets, range = "mtcars!B1:D5")
 
 # Read only specific rows or columns
 read_excel(datasets, range = cell_rows(102:151), col_names = FALSE)

--- a/tests/testthat/test-sheets.R
+++ b/tests/testthat/test-sheets.R
@@ -5,6 +5,10 @@ test_that("informative error when requesting non-existent sheet by name", {
     read_excel(test_sheet("iris-excel.xlsx"), sheet = "tulip"),
     "Sheet 'tulip' not found"
   )
+  expect_error(
+    read_excel(test_sheet("iris-excel.xlsx"), range = "tulip!A1:A1"),
+    "Sheet 'tulip' not found"
+  )
 })
 
 test_that("informative error when requesting non-existent sheet by position", {
@@ -29,6 +33,25 @@ test_that("invalid sheet values caught", {
     read_excel(test_sheet("iris-excel.xlsx"), sheet = rep(1L, 2)),
     "`sheet` must have length 1"
   )
+})
+
+test_that("sheet can be parsed out of range", {
+  direct <-
+    read_excel(test_sheet("iris-excel.xlsx"), sheet = "iris", range = "A1:A1")
+  indirect <-
+    read_excel(test_sheet("iris-excel.xlsx"), range = "iris!A1:A1")
+  expect_identical(direct, indirect)
+})
+
+test_that("double specification of sheet generates message and range wins", {
+  expect_message(
+    double <-
+      read_excel(test_sheet("sheet-xml-lookup.xlsx"),
+                 sheet = "Asia", range = "Oceania!A1:A1"),
+    "Two values given for `sheet`. Using the `sheet` found in `range`"
+  )
+  ref <- read_excel(test_sheet("sheet-xml-lookup.xlsx"),range = "Oceania!A1:A1")
+  expect_identical(double, ref)
 })
 
 test_that("sheet data xml target is explicitly looked up (#104, #80)", {


### PR DESCRIPTION
😎

``` r
library(readxl)
read_excel(readxl_example("datasets.xlsx"), range = "mtcars!B1:D5")
#> # A tibble: 4 × 3
#>     cyl  disp    hp
#>   <dbl> <dbl> <dbl>
#> 1     6   160   110
#> 2     6   160   110
#> 3     4   108    93
#> 4     6   258   110

read_excel(readxl_example("datasets.xlsx"), range = "bigfoot!B1:D5")
#> Error: Sheet 'bigfoot' not found
```