### PR TITLE
Don't let implicit skipping of empty rows screw up n_max; fixes #316

### DIFF
--- a/src/CellLimits.h
+++ b/src/CellLimits.h
@@ -53,6 +53,14 @@ public:
     }
   }
 
+  void update(const int minRow, const int maxRow,
+              const int minCol, const int maxCol) {
+    minRow_ = minRow;
+    maxRow_ = maxRow;
+    minCol_ = minCol;
+    maxCol_ = maxCol;
+  }
+
   bool contains(const XlsCell cell) const {
     return contains(cell.row(), cell.col());
   }

--- a/tests/testthat/test-n-max.R
+++ b/tests/testthat/test-n-max.R
@@ -75,3 +75,47 @@ test_that("n_max = nrows in dense sheet when col_names = FALSE", {
   df <- read_excel(test_sheet("iris-excel.xls"), n_max = 18, col_names = FALSE)
   expect_identical(nrow(df), 18L)
 })
+
+test_that("n_max directive survives implicit skipping of empty rows [xlsx]", {
+  ## col_names = TRUE
+  explicit <-
+    read_excel(test_sheet("geometry.xlsx"), skip = 2, n_max = 1)
+  implicit_skip_all <-
+    read_excel(test_sheet("geometry.xlsx"), n_max = 1)
+  mixed_skip <-
+    read_excel(test_sheet("geometry.xlsx"), skip = 1, n_max = 1)
+  expect_identical(explicit, implicit_skip_all)
+  expect_identical(explicit, mixed_skip)
+
+  ## col_names = FALSE
+  explicit <-
+    read_excel(test_sheet("geometry.xlsx"), skip = 2, n_max = 1, col_names = FALSE)
+  implicit_skip_all <-
+    read_excel(test_sheet("geometry.xlsx"), n_max = 1, col_names = FALSE)
+  mixed_skip <-
+    read_excel(test_sheet("geometry.xlsx"), skip = 1, n_max = 1, col_names = FALSE)
+  expect_identical(explicit, implicit_skip_all)
+  expect_identical(explicit, mixed_skip)
+})
+
+test_that("n_max directive survives implicit skipping of empty rows [xls]", {
+  ## col_names = TRUE
+  explicit <-
+    read_excel(test_sheet("geometry.xls"), skip = 2, n_max = 1)
+  implicit_skip_all <-
+    read_excel(test_sheet("geometry.xls"), n_max = 1)
+  mixed_skip <-
+    read_excel(test_sheet("geometry.xls"), skip = 1, n_max = 1)
+  expect_identical(explicit, implicit_skip_all)
+  expect_identical(explicit, mixed_skip)
+
+  ## col_names = FALSE
+  explicit <-
+    read_excel(test_sheet("geometry.xls"), skip = 2, n_max = 1, col_names = FALSE)
+  implicit_skip_all <-
+    read_excel(test_sheet("geometry.xls"), n_max = 1, col_names = FALSE)
+  mixed_skip <-
+    read_excel(test_sheet("geometry.xls"), skip = 1, n_max = 1, col_names = FALSE)
+  expect_identical(explicit, implicit_skip_all)
+  expect_identical(explicit, mixed_skip)
+})

--- a/tests/testthat/test-skipping.R
+++ b/tests/testthat/test-skipping.R
@@ -2,31 +2,33 @@ context("Skipping")
 
 skipping_xlsx <- test_sheet("skipping.xlsx")
 skipping_xls <- test_sheet("skipping.xls")
-df <- tibble::tribble(~ var1, ~ var2,
-                          NA,     NA,
-                      "v2,1", "v2,2",
-                          NA,     NA,
-                      "v4,1", "v4,2")
+ref <- tibble::tribble(
+  ~ var1, ~ var2,
+      NA,     NA,
+  "v2,1", "v2,2",
+      NA,     NA,
+  "v4,1", "v4,2"
+)
 
 test_that("leading blank rows are implicitly skipped", {
-  out <- read_excel(skipping_xlsx, sheet = "two_blank_rows")
-  expect_identical(df, out)
-  out <- read_excel(skipping_xls, sheet = "two_blank_rows")
-  expect_identical(df, out)
+  xlsx <- read_excel(skipping_xlsx, sheet = "two_blank_rows")
+  xls <- read_excel(skipping_xls, sheet = "two_blank_rows")
+  expect_identical(xlsx, ref)
+  expect_identical(xls, ref)
 })
 
 test_that("leading blank rows can be explicitly skipped", {
-  out <- read_excel(skipping_xlsx, sheet = "two_blank_rows", skip = 2)
-  expect_identical(df, out)
-  out <- read_excel(skipping_xls, sheet = "two_blank_rows", skip = 2)
-  expect_identical(df, out)
+  xlsx <- read_excel(skipping_xlsx, sheet = "two_blank_rows", skip = 2)
+  xls <- read_excel(skipping_xls, sheet = "two_blank_rows", skip = 2)
+  expect_identical(xlsx, ref)
+  expect_identical(xls, ref)
 })
 
 test_that("leading blank rows can be implicitly AND explicitly skipped", {
-  out <- read_excel(skipping_xlsx, sheet = "two_blank_rows", skip = 1)
-  expect_identical(df, out)
-  out <- read_excel(skipping_xls, sheet = "two_blank_rows", skip = 1)
-  expect_identical(df, out)
+  xlsx <- read_excel(skipping_xlsx, sheet = "two_blank_rows", skip = 1)
+  xls <- read_excel(skipping_xls, sheet = "two_blank_rows", skip = 1)
+  expect_identical(xlsx, ref)
+  expect_identical(xls, ref)
 })
 
 test_that("failure to skip junk leads to garbage df but no error", {
@@ -56,22 +58,22 @@ test_that("failure to skip junk leads to garbage df but no error", {
 })
 
 test_that("explicit skip of leading junk, implicit skip of blank rows", {
-  out <- read_excel(skipping_xlsx, sheet = "occupied_row_and_blank_row", skip = 1)
-  expect_identical(df, out)
-  out <- read_excel(skipping_xls, sheet = "occupied_row_and_blank_row", skip = 1)
-  expect_identical(df, out)
+  xlsx <- read_excel(skipping_xlsx, sheet = "occupied_row_and_blank_row", skip = 1)
+  xls <- read_excel(skipping_xls, sheet = "occupied_row_and_blank_row", skip = 1)
+  expect_identical(xlsx, ref)
+  expect_identical(xls, ref)
 })
 
 test_that("explicit skip of leading junk and blank rows", {
-  out <- read_excel(skipping_xlsx, sheet = "occupied_row_and_blank_row", skip = 2)
-  expect_identical(df, out)
-  out <- read_excel(skipping_xls, sheet = "occupied_row_and_blank_row", skip = 2)
-  expect_identical(df, out)
+  xlsx <- read_excel(skipping_xlsx, sheet = "occupied_row_and_blank_row", skip = 2)
+  xls <- read_excel(skipping_xls, sheet = "occupied_row_and_blank_row", skip = 2)
+  expect_identical(xlsx, ref)
+  expect_identical(xls, ref)
 })
 
 test_that("explicit skip of leading junk", {
-  out <- read_excel(skipping_xlsx, sheet = "two_occupied_rows", skip = 2)
-  expect_identical(out, df)
-  out <- read_excel(skipping_xls, sheet = "two_occupied_rows", skip = 2)
-  expect_identical(out, df)
+  xlsx <- read_excel(skipping_xlsx, sheet = "two_occupied_rows", skip = 2)
+  xls <- read_excel(skipping_xls, sheet = "two_occupied_rows", skip = 2)
+  expect_identical(ref, xlsx)
+  expect_identical(ref, xls)
 })


### PR DESCRIPTION
#316 = "n_max not honoured if leading empty rows are automatically skipped"

Noticed this problem when finishing off #314, the PR which added rectangular reading. #314 made cell loading more efficient by using CellLimit objects to store and reconcile the target rectangle and data rectangle. All in one pass.

But there's one case where CellLimits is awkward, because you need to know where the data is: when there are leading empty rows AND user specifies `n_max` = maximum number of data rows to read.

In this case, you need to read until you find a row that contains any data at all and adjust the nominal rectangle to start there and end `n_max` rows later.

The next time I refactor things -- maybe during the great xls/xlsx unification -- I will try to put some of this logic into the CellLimits class. But I think this is OK for now and maybe forever.