### PR TITLE
Clear warning re: 'long long'

### DIFF
--- a/cran-comments.md
+++ b/cran-comments.md
@@ -24,14 +24,14 @@ There are 2 NOTEs, that make three points:
 
 Two possibly invalid URLs are flagged, one in NEWS.md and another in a vignette. Both are valid URLs below https://support.microsoft.com that I have no trouble accessing. I'm not sure why they are flagged.
   
-Results from:
+Results re: current version from:
 https://cran.r-project.org/web/checks/check_results_readxl.html  
   
-All NOTEs are about registration of native routines, which has been addressed in this submission.
+  * All NOTEs are about registration of native routines, which has been addressed in this submission.
 
-There is one WARN for r-devel-windows-ix86+x86_64: "ISO C++ 1998 does not support 'long long' [-Wlong-long]". This originates in a typedef in the wrapped libxls library. COME BACK HERE ONCE MY ATTEMPT TO SUPPRESS HAS PLAYED OUT.
+  * There is one WARN for r-devel-windows-ix86+x86_64: "ISO C++ 1998 does not support 'long long' [-Wlong-long]". This originates in a typedef in the wrapped libxls library. There is existing conditional handling for Windows and we have now adapted it to look for _WIN32, in addition to WIN32. This clears the warning.
 
-There is one ERROR for r-patched-solaris-sparc, which has always been the case for this package. Repeating explanation from the previous CRAN release: The package still fails on solaris, due to endian-ness bugs in the wrapped libxls library.
+  * There is one ERROR for r-patched-solaris-sparc, which has always been the case for this package. Repeating explanation from the previous CRAN release: The package still fails on solaris, due to endian-ness bugs in the wrapped libxls library.
 
 ## Reverse dependencies
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -27,9 +27,7 @@ Two possibly invalid URLs are flagged, one in NEWS.md and another in a vignette.
 Results re: current version from:
 https://cran.r-project.org/web/checks/check_results_readxl.html  
   
-  * All NOTEs are about registration of native routines, which has been addressed in this submission.
-
-  * There is one WARN for r-devel-windows-ix86+x86_64: "ISO C++ 1998 does not support 'long long' [-Wlong-long]". This originates in a typedef in the wrapped libxls library. There is existing conditional handling for Windows and we have now adapted it to look for _WIN32, in addition to WIN32. This clears the warning.
+  * All NOTEs and WARNs have been cleared in this release. Native routines have been registered and we corrected the libxls issue with long long integers on Windows.
 
   * There is one ERROR for r-patched-solaris-sparc, which has always been the case for this package. Repeating explanation from the previous CRAN release: The package still fails on solaris, due to endian-ness bugs in the wrapped libxls library.
 

--- a/src/libxls/xlstypes.h
+++ b/src/libxls/xlstypes.h
@@ -48,7 +48,7 @@ typedef uint32_t			DWORD_UA	__attribute__ ((aligned (1)));	// 4 bytes
 #endif
 
 // Windows
-#if defined(_MSC_VER) && defined(WIN32)
+#if defined(WIN32) || defined(_WIN32)
 
 typedef unsigned __int64	unsigned64_t;
 

--- a/src/libxls/xlstypes.h
+++ b/src/libxls/xlstypes.h
@@ -48,7 +48,7 @@ typedef uint32_t			DWORD_UA	__attribute__ ((aligned (1)));	// 4 bytes
 #endif
 
 // Windows
-#if defined(WIN32) || defined(_WIN32)
+#if defined(_WIN32)
 
 typedef unsigned __int64	unsigned64_t;
 


### PR DESCRIPTION
There is an existing warning for readxl:

```
Found the following significant warnings:
  ./libxls/xlstypes.h:64:23: warning: ISO C++ 1998 does not support 'long long' [-Wlong-long]
```

https://www.r-project.org/nosvn/R.check/r-devel-windows-ix86+x86_64/readxl-00check.html

I also see this with current readxl on win builder -- [example](https://win-builder.r-project.org/6yR7GL6Vry35/00check.log). (r-hub is down right now, but I'm pretty sure I saw it on previous checks there this week.)

This PR adapts existing WIN32 handling in libxls to use `_WIN32`, which is defined for all Windows builds. According to win-builder, this will clear the warning -- [example](https://win-builder.r-project.org/4eee83JYoUfo/00check.log).

I also managed to clear it by adding `-Wno-long-long` to `PKG_CFLAGS` and `PKG_CPPFLAGS` in `src/Makevars.win`. But I found precious little precedent for such a fix when searching other CRAN packages via the GitHub mirror.

This September 2016 thread provides some context for this warning. Nothing in readxl / libxls has changed, but CRAN has changed something about their checks since readxl was last released (March 2016).

https://github.com/RcppCore/RcppParallel/issues/37

> And I'm guessing that a recent R-devel change is now causing R to compile with the -pedantic flag set on Windows, which triggers this warning on gcc 4.9.3.