### PR TITLE
Stop guessing if we're already at COL_TEXT

### DIFF
--- a/src/XlsWorkSheet.h
+++ b/src/XlsWorkSheet.h
@@ -112,7 +112,7 @@ public:
         Rcpp::checkUserInterrupt();
       }
       int j = xcell->col() - actual_.minCol();
-      if (type_known[j]) {
+      if (type_known[j] || types[j] == COL_TEXT) {
         xcell++;
         continue;
       }

--- a/src/XlsxWorkSheet.h
+++ b/src/XlsxWorkSheet.h
@@ -125,7 +125,7 @@ public:
         Rcpp::checkUserInterrupt();
       }
       int j = xcell->col() - actual_.minCol();
-      if (type_known[j]) {
+      if (type_known[j] || types[j] == COL_TEXT) {
         xcell++;
         continue;
       }


### PR DESCRIPTION
This is a minor tweak motivated by speed. Example: for one single large xlsx, created from a single wild-caught xls (>50K rows, >100 cols), this speeds up `read_excel()` by >25%. The speed up for xls version of this sheet is closer to 50%. Highly anecdotal, but seems like a sensible change regardless.