### PR TITLE
Parse _rels/.rels to get paths to package parts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # readxl 1.0.0.9000
 
+* xlsx structured as a "minimal conformant SpreadsheetML package" can be read. Most obvious feature of such sheets is the lack of an `xl/` directory in the unzipped form. (xlsx, #435, #437)
+
 * Reading xls sheet with exactly 65,536 rows no longer enters an infinite loop. (xls, #373, #416, #432 @vkapartzianis)
 
 * Datetimes coerced to character from xls have much higher precision, comparable to the xlsx behaviour. (xls, #430, #431)

--- a/src/XlsxWorkBook.h
+++ b/src/XlsxWorkBook.h
@@ -10,7 +10,7 @@
 
 class XlsxWorkBook {
 
-  // holds objects related to package parts, such file paths, but also
+  // holds objects related to package parts, such as file paths, but also
   // worksheet position, name, and id
   class PackageRelations {
     // non-worksheet package parts
@@ -55,7 +55,7 @@ class XlsxWorkBook {
         Rcpp::stop("No workbook part found");
       }
       // store 'xl/workbook.xml', not '/xl/workbook.xml' (rare, but have seen)
-      part_["officeDocument"] = deSlash(m->second);
+      part_["officeDocument"] = removeLeadingSlashes(m->second);
     }
 
     // populates n_, names_, id_
@@ -105,7 +105,7 @@ class XlsxWorkBook {
       const std::string workbook_dir = dirName(workbook_path);
       std::string rels_xml_path =
         workbook_dir + "/_rels/" + baseName(workbook_path) + ".rels";
-      rels_xml_path = deSlash(rels_xml_path);
+      rels_xml_path = removeLeadingSlashes(rels_xml_path);
       std::string rels_xml_file = zip_buffer(path, rels_xml_path);
 
       rapidxml::xml_document<> rels_xml;
@@ -125,7 +125,7 @@ class XlsxWorkBook {
 
         if (id != NULL && type != NULL && target != NULL) {
           // store 'xl/blah' instead of '/xl/blah' (rare, but we've seen)
-          std::string target_value = deSlash(target->value());
+          std::string target_value = removeLeadingSlashes(target->value());
           // abbreviate Type
           // in XML: http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings
           // whereas we only want: sharedStrings

--- a/src/utils.h
+++ b/src/utils.h
@@ -145,4 +145,25 @@ inline std::string trim(const std::string& s) {
   return s.substr(begin, end - begin + 1);
 }
 
+inline std::string dirName(const std::string& path) {
+  std::size_t found = path.find_last_of("/");
+  if (found == std::string::npos) {
+    return "";
+  }
+  return path.substr(0, found);
+}
+
+inline std::string baseName(const std::string& path) {
+  std::size_t found = path.find_last_of("/");
+  if (found == std::string::npos) {
+    return path;
+  }
+  return path.substr(found + 1);
+}
+
+inline std::string deSlash(const std::string& s) {
+  size_t start = s.find_first_not_of("/");
+  return s.substr(start);
+}
+
 #endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -161,8 +161,11 @@ inline std::string baseName(const std::string& path) {
   return path.substr(found + 1);
 }
 
-inline std::string deSlash(const std::string& s) {
+inline std::string removeLeadingSlashes(const std::string& s) {
   size_t start = s.find_first_not_of("/");
+  if (start == std::string::npos) {
+    return "";
+  }
   return s.substr(start);
 }
 

--- a/src/zip.cpp
+++ b/src/zip.cpp
@@ -48,4 +48,3 @@ void zip_xml(const std::string& zip_path,
   std::string buffer = zip_buffer(zip_path, file_path);
   Rcout << xml_print(buffer);
 }
-

--- a/tests/testthat/test-compatibility.R
+++ b/tests/testthat/test-compatibility.R
@@ -44,6 +44,7 @@ test_that("we can read the BIFF5, LABEL record sheet", {
   expect_identical(df$Time[c(1, 14)], c("01:00", "14:00"))
 })
 
+
 ## https://github.com/tidyverse/readxl/pull/429
 ## <c r="C2" s="1" t="str"><f>A2 + B2</f></c>
 test_that("formula cell with no v node does not cause crash", {
@@ -51,4 +52,17 @@ test_that("formula cell with no v node does not cause crash", {
     df <- read_excel(test_sheet("missing-v-node-xlsx.xlsx"))
   )
   expect_identical(df$`A + B`, NA)
+})
+
+## https://github.com/tidyverse/readxl/issues/435
+## https://source.opennews.org/articles/how-we-found-new-patterns-la-homeless-arrest/
+## LAPD uses a tool to produce xlsx that implements the minimal SpreadsheetML
+## package structure described on pp65-66 of ECMA 5th edition
+test_that("we can read LAPD arrest sheets", {
+  expect_silent(
+    lapd <- read_excel(test_sheet("los-angeles-arrests-xlsx.xlsx"), skip = 2)
+  )
+  expect_identical(dim(lapd), c(193L, 36L))
+  expect_match(lapd$ARR_LOC[9], "HOLLYWOOD")
+  expect_identical(lapd$CHG_DESC[27], "EX CON W/ A GUN")
 })


### PR DESCRIPTION
Fixes #435 Be able to read sheets produced by the Los Angeles Police Department

The xlsx produced by LAPD is a very literal implementation of the example on pp65-66 of 5th edition of ECMA:

> Example: The following package represents the minimal conformant SpreadsheetML package as defined by ECMA-376

I used this as motivation to make a major upgrade to how readxl parses the package structure. Basically, readxl previously did not parse it but, rather, assumed a very common default. And the LAPD sheets show that other structures are possible (Excel can open the LAPD files, btw). Now we can read LAPD sheets, while still being able to read all the other weird 3rd party sheets in our test collection 🤞

The main feature of the LAPD sheets is that they do not use an `xl/` subdirectory, whereas every other xlsx we've seen before does. Browsable examples:

  * LAPD sheets do not use an `xl/` subdirectory: [excelgesis/los-angeles-arrests-xlsx](https://jennybc.github.io/excelgesis/los-angeles-arrests-xlsx/index.html)
  * [excelgesis/embedded-chartsheet](https://jennybc.github.io/excelgesis/embedded-chartsheet/index.html) is a good example of a "normal" xlsx with multiple worksheets and a chartsheet. It has an `xl/` subdirectory.
  * [excelgesis/Ekaterinburg_IP_9](https://jennybc.github.io/excelgesis/Ekaterinburg_IP_9/index.html) is a valuable example of yet another type of 3rd party xlsx. It uses `xl/` but insists on giving paths in `/xl/foo/bar` form in all the relationship files, which is peculiar (very different from embedded-chartsheet example). It's also completely in Cyrillic, which is extra fun.