### PR TITLE
Switch to tibble::set_tidy_names() from tibble::repair_names()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # readxl 1.0.0.9000
 
+* Missing or duplicated column names are now repaired with `tibble::set_tidy_names()` in `read_excel()` and friends. `set_tidy_names()` is intended to implement a standard across the tidyverse packages for repairing missing and duplicated names. Its design is discussed in [tidyverse/tibble#217](https://github.com/tidyverse/tibble/issues/217). (PR here, #357)
+
 * Embedded libxls has been updated to address security vulnerabilitities identified in late 2017 (#441, #442).
 
   - [CVE-2017-12110](https://www.talosintelligence.com/vulnerability_reports/TALOS-2017-0462), [CVE-2017-2896](https://www.talosintelligence.com/vulnerability_reports/TALOS-2017-0403), and [CVE-2017-2897](https://www.talosintelligence.com/vulnerability_reports/TALOS-2017-0404) were demonstrated to affect readxl v1.0.0. These have been addressed in libxls and the embedded version of libxls incorporates those fixes.

--- a/R/excel-sheets.R
+++ b/R/excel-sheets.R
@@ -13,7 +13,7 @@ excel_sheets <- function(path) {
   format <- check_format(path)
 
   switch(format,
-    xls =  xls_sheets(path),
+    xls = xls_sheets(path),
     xlsx = xlsx_sheets(path)
   )
 }

--- a/R/read_excel.R
+++ b/R/read_excel.R
@@ -27,8 +27,8 @@ NULL
 #'   frame output. A list cell loads a column as a list of length 1 vectors,
 #'   which are typed using the type guessing logic from `col_types = NULL`, but
 #'   on a cell-by-cell basis.
-#' @param na Character vector of strings to interpret as missing values. By default,
-#'   readxl treats blank cells as missing data.
+#' @param na Character vector of strings to interpret as missing values. By
+#'   default, readxl treats blank cells as missing data.
 #' @param trim_ws Should leading and trailing whitespace be trimmed?
 #' @param skip Minimum number of rows to skip before reading anything, be it
 #'   column names or data. Leading empty rows are automatically skipped, so this
@@ -102,7 +102,7 @@ read_excel <- function(path, sheet = NULL, range = NULL,
 #' @export
 read_xls <- function(path, sheet = NULL, range = NULL,
                      col_names = TRUE, col_types = NULL,
-                     na = "",  trim_ws = TRUE, skip = 0, n_max = Inf,
+                     na = "", trim_ws = TRUE, skip = 0, n_max = Inf,
                      guess_max = min(1000, n_max)) {
   read_excel_(
     path = path, sheet = sheet, range = range,
@@ -116,7 +116,7 @@ read_xls <- function(path, sheet = NULL, range = NULL,
 #' @export
 read_xlsx <- function(path, sheet = NULL, range = NULL,
                       col_names = TRUE, col_types = NULL,
-                      na = "",  trim_ws = TRUE, skip = 0, n_max = Inf,
+                      na = "", trim_ws = TRUE, skip = 0, n_max = Inf,
                       guess_max = min(1000, n_max)) {
   read_excel_(
     path = path, sheet = sheet, range = range,
@@ -128,7 +128,7 @@ read_xlsx <- function(path, sheet = NULL, range = NULL,
 
 read_excel_ <- function(path, sheet = NULL, range = NULL,
                         col_names = TRUE, col_types = NULL,
-                        na = "",  trim_ws = TRUE, skip = 0, n_max = Inf,
+                        na = "", trim_ws = TRUE, skip = 0, n_max = Inf,
                         guess_max = min(1000, n_max), format) {
   path <- check_file(path)
   if (format == "xls") {
@@ -140,16 +140,20 @@ read_excel_ <- function(path, sheet = NULL, range = NULL,
   }
   sheet <- standardise_sheet(sheet, range, sheets_fun(path))
   shim <- !is.null(range)
-  limits <- standardise_limits(range, skip, n_max, has_col_names = isTRUE(col_names))
+  limits <- standardise_limits(
+    range, skip, n_max, has_col_names = isTRUE(col_names)
+  )
   col_types <- check_col_types(col_types)
   guess_max <- check_guess_max(guess_max)
   trim_ws <- check_bool(trim_ws, "trim_ws")
   tibble::repair_names(
     tibble::as_tibble(
-      read_fun(path = path, sheet_i = sheet,
-               limits = limits, shim = shim,
-               col_names = col_names, col_types = col_types,
-               na = na, trim_ws = trim_ws, guess_max = guess_max),
+      read_fun(
+        path = path, sheet_i = sheet,
+        limits = limits, shim = shim,
+        col_names = col_names, col_types = col_types,
+        na = na, trim_ws = trim_ws, guess_max = guess_max
+      ),
       validate = FALSE
     ),
     prefix = "X", sep = "__"
@@ -185,8 +189,10 @@ standardise_sheet <- function(sheet, range, sheet_names) {
   range_sheet <- cellranger::as.cell_limits(range)[["sheet"]]
   if (!is.null(range_sheet) && !is.na(range_sheet)) {
     if (!is.null(sheet)) {
-      message("Two values given for `sheet`. ",
-              "Using the `sheet` found in `range`:\n", range_sheet)
+      message(
+        "Two values given for `sheet`. ",
+        "Using the `sheet` found in `range`:\n", range_sheet
+      )
     }
     sheet <- range_sheet
   }
@@ -277,7 +283,7 @@ check_bool <- function(bool, arg_name) {
 
 check_non_negative_integer <- function(i, arg_name) {
   if (length(i) != 1 || !is.numeric(i) || !is_integerish(i) ||
-      is.na(i) || i < 0) {
+    is.na(i) || i < 0) {
     stop("`", arg_name, "` must be a positive integer", call. = FALSE)
   }
   i
@@ -287,8 +293,10 @@ check_non_negative_integer <- function(i, arg_name) {
 check_guess_max <- function(guess_max, max_limit = .Machine$integer.max %/% 100) {
   guess_max <- check_non_negative_integer(guess_max, "guess_max")
   if (guess_max > max_limit) {
-    warning("`guess_max` is a very large value, setting to `", max_limit,
-            "` to avoid exhausting memory", call. = FALSE)
+    warning(
+      "`guess_max` is a very large value, setting to `", max_limit,
+      "` to avoid exhausting memory", call. = FALSE
+    )
     guess_max <- max_limit
   }
   guess_max

--- a/R/read_excel.R
+++ b/R/read_excel.R
@@ -146,7 +146,7 @@ read_excel_ <- function(path, sheet = NULL, range = NULL,
   col_types <- check_col_types(col_types)
   guess_max <- check_guess_max(guess_max)
   trim_ws <- check_bool(trim_ws, "trim_ws")
-  tibble::repair_names(
+  tibble::set_tidy_names(
     tibble::as_tibble(
       read_fun(
         path = path, sheet_i = sheet,
@@ -155,8 +155,7 @@ read_excel_ <- function(path, sheet = NULL, range = NULL,
         na = na, trim_ws = trim_ws, guess_max = guess_max
       ),
       validate = FALSE
-    ),
-    prefix = "X", sep = "__"
+    )
   )
 }
 

--- a/man/read_excel.Rd
+++ b/man/read_excel.Rd
@@ -47,8 +47,8 @@ frame output. A list cell loads a column as a list of length 1 vectors,
 which are typed using the type guessing logic from \code{col_types = NULL}, but
 on a cell-by-cell basis.}
 
-\item{na}{Character vector of strings to interpret as missing values. By default,
-readxl treats blank cells as missing data.}
+\item{na}{Character vector of strings to interpret as missing values. By
+default, readxl treats blank cells as missing data.}
 
 \item{trim_ws}{Should leading and trailing whitespace be trimmed?}
 

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -5,3 +5,7 @@ test_sheet <- function(fname) rprojroot::find_testthat_root_file("sheets", fname
 ## once https://github.com/hadley/testthat/commit/c83aba9 is on CRAN
 ## can use testthat::test_path() for this, i.e.,
 # test_sheet <- function(fname) testthat::test_path("sheets", fname)
+
+expect_error_free <- function(...) {
+  expect_error(..., regexp = NA)
+}

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -4,4 +4,4 @@ test_sheet <- function(fname) rprojroot::find_testthat_root_file("sheets", fname
 
 ## once https://github.com/hadley/testthat/commit/c83aba9 is on CRAN
 ## can use testthat::test_path() for this, i.e.,
-#test_sheet <- function(fname) testthat::test_path("sheets", fname)
+# test_sheet <- function(fname) testthat::test_path("sheets", fname)

--- a/tests/testthat/test-coercion.R
+++ b/tests/testthat/test-coercion.R
@@ -3,8 +3,10 @@ context("coercion")
 test_that("contaminated, explicit logical is read as logical", {
   ## xls
   expect_warning(
-    df <- read_excel(test_sheet("types.xls"), sheet = "logical_coercion",
-                     col_types = c("logical", "text")),
+    df <- read_excel(
+      test_sheet("types.xls"), sheet = "logical_coercion",
+      col_types = c("logical", "text")
+    ),
     "Expecting logical",
     all = TRUE
   )
@@ -14,8 +16,10 @@ test_that("contaminated, explicit logical is read as logical", {
 
   ## xlsx
   expect_warning(
-    df <- read_excel(test_sheet("types.xlsx"), sheet = "logical_coercion",
-                     col_types = c("logical", "text")),
+    df <- read_excel(
+      test_sheet("types.xlsx"), sheet = "logical_coercion",
+      col_types = c("logical", "text")
+    ),
     "Expecting logical",
     all = TRUE
   )
@@ -27,8 +31,10 @@ test_that("contaminated, explicit logical is read as logical", {
 test_that("contaminated, explicit date is read as date", {
   ## xls
   expect_warning(
-    df <- read_excel(test_sheet("types.xls"), sheet = "date_coercion",
-                     col_types = "date"),
+    df <- read_excel(
+      test_sheet("types.xls"), sheet = "date_coercion",
+      col_types = "date"
+    ),
     "Expecting date|Coercing numeric",
     all = TRUE
   )
@@ -39,8 +45,10 @@ test_that("contaminated, explicit date is read as date", {
 
   ## xlsx
   expect_warning(
-    df <- read_excel(test_sheet("types.xlsx"), sheet = "date_coercion",
-                     col_types = "date"),
+    df <- read_excel(
+      test_sheet("types.xlsx"), sheet = "date_coercion",
+      col_types = "date"
+    ),
     "Expecting date|Coercing numeric",
     all = TRUE
   )
@@ -53,8 +61,10 @@ test_that("contaminated, explicit date is read as date", {
 test_that("contaminated, explicit numeric is read as numeric", {
   ## xls
   expect_warning(
-    df <- read_excel(test_sheet("types.xls"), sheet = "numeric_coercion",
-                     col_types = "numeric"),
+    df <- read_excel(
+      test_sheet("types.xls"), sheet = "numeric_coercion",
+      col_types = "numeric"
+    ),
     "Expecting numeric|Coercing boolean|Coercing text",
     all = TRUE
   )
@@ -64,8 +74,10 @@ test_that("contaminated, explicit numeric is read as numeric", {
 
   ## xlsx
   expect_warning(
-    df <- read_excel(test_sheet("types.xlsx"), sheet = "numeric_coercion",
-                     col_types = "numeric"),
+    df <- read_excel(
+      test_sheet("types.xlsx"), sheet = "numeric_coercion",
+      col_types = "numeric"
+    ),
     "Expecting numeric|Coercing boolean|Coercing text",
     all = TRUE
   )
@@ -78,21 +90,24 @@ test_that("contaminated, explicit numeric is read as numeric", {
 ## i.e. don't right pad to get 6 decimal places
 test_that("contaminated, explicit text is read as text", {
   ## xls
-  df <- read_excel(test_sheet("types.xls"), sheet = "text_coercion",
-                   col_types = c("text", "text"))
+  df <- read_excel(
+    test_sheet("types.xls"), sheet = "text_coercion",
+    col_types = c("text", "text")
+  )
   expect_is(df$text, "character")
   expect_false(anyNA(df$explanation != "blank"))
   expect_identical(df$text[df$explanation == "floating point"], "1.3")
   expect_identical(df$text[df$explanation == "student number"], "36436153")
 
   ## xlsx
-  df <- read_excel(test_sheet("types.xlsx"), sheet = "text_coercion",
-                   col_types = c("text", "text"))
+  df <- read_excel(
+    test_sheet("types.xlsx"), sheet = "text_coercion",
+    col_types = c("text", "text")
+  )
   expect_is(df$text, "character")
   expect_false(anyNA(df$explanation != "blank"))
   expect_identical(df$text[df$explanation == "floating point"], "1.3")
   expect_identical(df$text[df$explanation == "student number"], "36436153")
-
 })
 
 test_that("integery-y numbers > 2^31 can be coerced to string", {

--- a/tests/testthat/test-col-names.R
+++ b/tests/testthat/test-col-names.R
@@ -61,7 +61,7 @@ test_that("column names are de-duplicated", {
 test_that("wrong length column names are rejected", {
   err_msg <- "Sheet 1 has 5 columns (5 unskipped), but `col_names` has length 3."
   expect_error(
-    read_excel(test_sheet("iris-excel-xlsx.xlsx"),col_names = LETTERS[1:3]),
+    read_excel(test_sheet("iris-excel-xlsx.xlsx"), col_names = LETTERS[1:3]),
     err_msg,
     fixed = TRUE
   )
@@ -76,18 +76,22 @@ test_that("column_names can anticipate skipping", {
 
   ## xlsx
   expect_silent(
-    df <- read_excel(test_sheet("iris-excel-xlsx.xlsx"),
-                     col_names = c("one", "two", "three"), skip = 1,
-                     col_types = c("numeric", "numeric", "skip", "skip", "text"))
+    df <- read_excel(
+      test_sheet("iris-excel-xlsx.xlsx"),
+      col_names = c("one", "two", "three"), skip = 1,
+      col_types = c("numeric", "numeric", "skip", "skip", "text")
+    )
   )
   expect_identical(dim(df), c(150L, 3L))
   expect_identical(names(df), c("one", "two", "three"))
 
   ## xls
   expect_silent(
-    df <- read_excel(test_sheet("iris-excel-xls.xls"),
-                     col_names = c("one", "two", "three"), skip = 1,
-                     col_types = c("numeric", "numeric", "skip", "skip", "text"))
+    df <- read_excel(
+      test_sheet("iris-excel-xls.xls"),
+      col_names = c("one", "two", "three"), skip = 1,
+      col_types = c("numeric", "numeric", "skip", "skip", "text")
+    )
   )
   expect_identical(dim(df), c(150L, 3L))
   expect_identical(names(df), c("one", "two", "three"))

--- a/tests/testthat/test-col-names.R
+++ b/tests/testthat/test-col-names.R
@@ -46,16 +46,16 @@ test_that("col_names = FALSE mimics missing column names [xls]", {
 
 test_that("missing column names are populated", {
   df <- read_excel(test_sheet("unnamed-duplicated-columns.xlsx"))
-  expect_identical(names(df)[c(1, 3)], c("X__1", "X__2"))
+  expect_identical(names(df)[c(1, 3)], c("..1", "..3"))
   df <- read_excel(test_sheet("unnamed-duplicated-columns.xls"))
-  expect_identical(names(df)[c(1, 3)], c("X__1", "X__2"))
+  expect_identical(names(df)[c(1, 3)], c("..1", "..3"))
 })
 
 test_that("column names are de-duplicated", {
   df <- read_excel(test_sheet("unnamed-duplicated-columns.xlsx"))
-  expect_identical(names(df)[4], "var2__1")
+  expect_identical(names(df)[4], "var2..4")
   df <- read_excel(test_sheet("unnamed-duplicated-columns.xls"))
-  expect_identical(names(df)[4], "var2__1")
+  expect_identical(names(df)[4], "var2..4")
 })
 
 test_that("wrong length column names are rejected", {

--- a/tests/testthat/test-col-types.R
+++ b/tests/testthat/test-col-types.R
@@ -2,16 +2,20 @@ context("Column types")
 
 test_that("illegal col_types are rejected", {
   expect_error(
-    read_excel(test_sheet("types.xlsx"),
-               col_types = c("foo", "numeric", "text", "bar")),
+    read_excel(
+      test_sheet("types.xlsx"),
+      col_types = c("foo", "numeric", "text", "bar")
+    ),
     "Illegal column type"
   )
 })
 
 test_that("request for 'blank' col type gets deprecation message and fix", {
   expect_message(
-    read_excel(test_sheet("types.xlsx"),
-               col_types = rep_len(c("blank", "text"), length.out = 5)),
+    read_excel(
+      test_sheet("types.xlsx"),
+      col_types = rep_len(c("blank", "text"), length.out = 5)
+    ),
     "`col_type = \"blank\"` deprecated. Use \"skip\" instead.",
     fixed = TRUE
   )
@@ -33,11 +37,15 @@ test_that("invalid col_types are rejected", {
 })
 
 test_that("col_types can be specified", {
-  df <- read_excel(test_sheet("iris-excel-xlsx.xlsx"),
-                   col_types = c("numeric", "text", "numeric", "numeric", "text"))
+  df <- read_excel(
+    test_sheet("iris-excel-xlsx.xlsx"),
+    col_types = c("numeric", "text", "numeric", "numeric", "text")
+  )
   expect_is(df[[2]], "character")
-  df <- read_excel(test_sheet("iris-excel-xls.xls"),
-                   col_types = c("numeric", "text", "numeric", "numeric", "text"))
+  df <- read_excel(
+    test_sheet("iris-excel-xls.xls"),
+    col_types = c("numeric", "text", "numeric", "numeric", "text")
+  )
   expect_is(df[[2]], "character")
 })
 
@@ -127,7 +135,7 @@ test_that("list column reads data correctly [xlsx]", {
 })
 
 test_that("setting `na` works in list columns [xlsx]", {
-  na_defined <-  read_excel(test_sheet("list_type.xlsx"), col_types = "list", na = "a")
+  na_defined <- read_excel(test_sheet("list_type.xlsx"), col_types = "list", na = "a")
   expect_equal(na_defined$var1[[3]], NA)
 })
 
@@ -142,7 +150,7 @@ test_that("list column reads data correctly [xls]", {
 })
 
 test_that("setting `na` works in list columns [xls]", {
-  na_defined <-  read_excel(test_sheet("list_type.xls"), col_types = "list", na = "a")
+  na_defined <- read_excel(test_sheet("list_type.xls"), col_types = "list", na = "a")
   expect_equal(na_defined$var1[[3]], NA)
 })
 

--- a/tests/testthat/test-compatibility.R
+++ b/tests/testthat/test-compatibility.R
@@ -61,7 +61,7 @@ test_that("formula cell with no v node does not cause crash", {
 ## LAPD uses a tool to produce xlsx that implements the minimal SpreadsheetML
 ## package structure described on pp65-66 of ECMA 5th edition
 test_that("we can read LAPD arrest sheets", {
-  expect_silent(
+  expect_error_free(
     lapd <- read_excel(test_sheet("los-angeles-arrests-xlsx.xlsx"), skip = 2)
   )
   expect_identical(dim(lapd), c(193L, 36L))

--- a/tests/testthat/test-compatibility.R
+++ b/tests/testthat/test-compatibility.R
@@ -27,7 +27,7 @@ test_that("we can finally read Ekaterinburg", {
   expect_silent(
     ek <- read_excel(test_sheet("Ekaterinburg_IP_9.xlsx"), skip = 2)
   )
-  expect_identical(ek[[1,2]], "27.05.2004")
+  expect_identical(ek[[1, 2]], "27.05.2004")
 })
 
 ## #309
@@ -37,8 +37,10 @@ test_that("we can finally read Ekaterinburg", {
 ## the shared string table, but causes difficulty when parsing LABEL records.
 ## We have a small patch now in libxls for that.
 test_that("we can read the BIFF5, LABEL record sheet", {
-  df <- read_excel(test_sheet("biff5-label-records.xls"), skip = 2,
-                   na = c("", "--"))
+  df <- read_excel(
+    test_sheet("biff5-label-records.xls"), skip = 2,
+    na = c("", "--")
+  )
   expect_identical(dim(df), c(14L, 4L))
   expect_identical(df$Date[c(1, 14)], c("21/01/2017", "21/01/2017"))
   expect_identical(df$Time[c(1, 14)], c("01:00", "14:00"))

--- a/tests/testthat/test-dates.R
+++ b/tests/testthat/test-dates.R
@@ -27,8 +27,10 @@ test_that("date subsecond rounding works", {
 test_that("we get correct dates prior to March 1, 1900, in 1900 date system", {
   ## xlsx
   expect_warning(
-    df <- read_excel(test_sheet("dates-leap-year-1900-xlsx.xlsx"),
-                     col_types = c("date", "text", "logical")),
+    df <- read_excel(
+      test_sheet("dates-leap-year-1900-xlsx.xlsx"),
+      col_types = c("date", "text", "logical")
+    ),
     "NA inserted for impossible 1900-02-29 datetime"
   )
   dttms <- as.POSIXct(df$dttm_string, format = "%Y-%m-%d %H:%M:%S", tz = "UTC")
@@ -38,8 +40,10 @@ test_that("we get correct dates prior to March 1, 1900, in 1900 date system", {
 
   ## xls
   expect_warning(
-    df <- read_excel(test_sheet("dates-leap-year-1900-xls.xls"),
-                     col_types = c("date", "text", "logical")),
+    df <- read_excel(
+      test_sheet("dates-leap-year-1900-xls.xls"),
+      col_types = c("date", "text", "logical")
+    ),
     "NA inserted for impossible 1900-02-29 datetime"
   )
   dttms <- as.POSIXct(df$dttm_string, format = "%Y-%m-%d %H:%M:%S", tz = "UTC")

--- a/tests/testthat/test-geometry.R
+++ b/tests/testthat/test-geometry.R
@@ -15,8 +15,10 @@ test_that("we can say 'read nothing' via n_max and col_names", {
   ##      -2      -1      -1      -1
 
   ## it should not matter what skip is
-  l2 <- standardise_limits(range = NULL, skip = sample(1:100, 1),
-                           n_max = 0, has_col_names = FALSE)
+  l2 <- standardise_limits(
+    range = NULL, skip = sample(1:100, 1),
+    n_max = 0, has_col_names = FALSE
+  )
   expect_identical(l, l2)
 })
 
@@ -213,5 +215,4 @@ test_that("open rectangles work", {
   xlsx <- read_excel(test_sheet("geometry.xlsx"), range = lims)
   expect_identical(xls, xlsx)
   expect_identical(dim(xls), c(2L, 2L))
-
 })

--- a/tests/testthat/test-missing-values.R
+++ b/tests/testthat/test-missing-values.R
@@ -67,7 +67,7 @@ test_that("na arg works with multiple strings and for shared strings [xlsx]", {
   ## sst[3] = "d"
   expect_identical(df, tibble::tribble(
     ~ a, ~ c,
-    "b",  NA
+    "b", NA
   ))
 })
 
@@ -78,7 +78,7 @@ test_that("na arg works with multiple strings and for shared strings [xls]", {
   )
   expect_identical(df, tibble::tribble(
     ~ a, ~ c,
-    "b",  NA
+    "b", NA
   ))
 })
 

--- a/tests/testthat/test-missing-values.R
+++ b/tests/testthat/test-missing-values.R
@@ -120,7 +120,7 @@ test_that("empty (styled) cells are not loaded, but can survive as NA [xlsx]", {
     var1 = c("val1,1", "val2,1", "val3,1"),
     var2 = NA,
     var3 = c("aa", "bb", "cc"),
-    X__1 = NA,
+     ..4 = NA,
     var5 = c(1, 2, 3)
   )
   expect_equal(out, df)
@@ -132,7 +132,7 @@ test_that("empty (styled) cells are not loaded, but can survive as NA [xls]", {
     var1 = c("val1,1", "val2,1", "val3,1"),
     var2 = NA,
     var3 = c("aa", "bb", "cc"),
-    X__1 = NA,
+     ..4 = NA,
     var5 = c(1, 2, 3)
   )
   expect_equal(out, df)

--- a/tests/testthat/test-n-max.R
+++ b/tests/testthat/test-n-max.R
@@ -20,48 +20,64 @@ test_that("simple use of n_max works and does not affect col name reading", {
 
 test_that("n_max = 0 and col_names = FALSE gives empty tibble", {
   ## xlsx
-  df <- read_excel(test_sheet("skipping.xlsx"), sheet = "two_occupied_rows",
-                   n_max = 0, col_names = FALSE)
+  df <- read_excel(
+    test_sheet("skipping.xlsx"), sheet = "two_occupied_rows",
+    n_max = 0, col_names = FALSE
+  )
   expect_identical(df, tibble::tibble())
 
   ## xls
-  df <- read_excel(test_sheet("skipping.xls"), sheet = "two_occupied_rows",
-                   n_max = 0, col_names = FALSE)
+  df <- read_excel(
+    test_sheet("skipping.xls"), sheet = "two_occupied_rows",
+    n_max = 0, col_names = FALSE
+  )
   expect_identical(df, tibble::tibble())
 })
 
 test_that("n_max is upper bound on nrows, if it causes trailing blank row", {
   ## xlsx
-  df <- read_excel(test_sheet("skipping.xlsx"), sheet = "two_occupied_rows",
-                   n_max = 3)
+  df <- read_excel(
+    test_sheet("skipping.xlsx"), sheet = "two_occupied_rows",
+    n_max = 3
+  )
   expect_identical(nrow(df), 2L)
 
   ## xls
-  df <- read_excel(test_sheet("skipping.xls"), sheet = "two_occupied_rows",
-                   n_max = 3)
+  df <- read_excel(
+    test_sheet("skipping.xls"), sheet = "two_occupied_rows",
+    n_max = 3
+  )
   expect_identical(nrow(df), 2L)
 })
 
 test_that("n_max can affect ncols, if prevents read of data in a col [xlsx]", {
   ## xlsx
-  df <- read_excel(test_sheet("skipping.xlsx"), sheet = "two_occupied_rows",
-                   n_max = 0)
+  df <- read_excel(
+    test_sheet("skipping.xlsx"), sheet = "two_occupied_rows",
+    n_max = 0
+  )
   expect_identical(nrow(df), 0L)
   expect_identical(ncol(df), 1L)
-  df <- read_excel(test_sheet("skipping.xlsx"), sheet = "two_occupied_rows",
-                   skip = 1, n_max = 0)
+  df <- read_excel(
+    test_sheet("skipping.xlsx"), sheet = "two_occupied_rows",
+    skip = 1, n_max = 0
+  )
   expect_identical(nrow(df), 0L)
   expect_identical(ncol(df), 1L)
 })
 
 test_that("n_max can affect ncols, if prevents read of data in a col [xls]", {
   ## xls
-  df <- read_excel(test_sheet("skipping.xls"), sheet = "two_occupied_rows",
-                   n_max = 0)
+  df <- read_excel(
+    test_sheet("skipping.xls"), sheet = "two_occupied_rows",
+    n_max = 0
+  )
   expect_identical(nrow(df), 0L)
   expect_identical(ncol(df), 1L)
-  df <- read_excel(test_sheet("skipping.xls"), sheet = "two_occupied_rows",
-                   skip = 1, n_max = 0)
+  df <- read_excel(
+    test_sheet("skipping.xls"), sheet = "two_occupied_rows",
+    skip = 1, n_max = 0
+  )
   expect_identical(nrow(df), 0L)
   expect_identical(ncol(df), 1L)
 })

--- a/tests/testthat/test-problems.R
+++ b/tests/testthat/test-problems.R
@@ -3,33 +3,43 @@ context("Problems")
 test_that("coercion warnings report correct address", {
   ## xlsx
   expect_warning(
-    read_excel(test_sheet("geometry.xlsx"), sheet = "warning_B6",
-               col_types = "numeric"),
+    read_excel(
+      test_sheet("geometry.xlsx"), sheet = "warning_B6",
+      col_types = "numeric"
+    ),
     "Expecting numeric in B6 / R6C2",
     fixed = TRUE
   )
   expect_warning(
-    read_excel(test_sheet("geometry.xlsx"), sheet = "warning_AT6",
-               col_types = "numeric"),
+    read_excel(
+      test_sheet("geometry.xlsx"), sheet = "warning_AT6",
+      col_types = "numeric"
+    ),
     "Expecting numeric in AT6 / R6C46",
     fixed = TRUE
   )
   expect_warning(
-    read_excel(test_sheet("geometry.xlsx"), sheet = "warning_AKE6",
-               col_types = "numeric"),
+    read_excel(
+      test_sheet("geometry.xlsx"), sheet = "warning_AKE6",
+      col_types = "numeric"
+    ),
     "Expecting numeric in AKE6 / R6C967",
     fixed = TRUE
   )
   ## xls
   expect_warning(
-    read_excel(test_sheet("geometry.xls"), sheet = "warning_B6",
-               col_types = "numeric"),
+    read_excel(
+      test_sheet("geometry.xls"), sheet = "warning_B6",
+      col_types = "numeric"
+    ),
     "Expecting numeric in B6 / R6C2",
     fixed = TRUE
   )
   expect_warning(
-    read_excel(test_sheet("geometry.xls"), sheet = "warning_AT6",
-               col_types = "numeric"),
+    read_excel(
+      test_sheet("geometry.xls"), sheet = "warning_AT6",
+      col_types = "numeric"
+    ),
     "Expecting numeric in AT6 / R6C46",
     fixed = TRUE
   )

--- a/tests/testthat/test-read-excel.R
+++ b/tests/testthat/test-read-excel.R
@@ -33,7 +33,6 @@ test_that("non-existent file throws error", {
 })
 
 test_that("read_excel catches invalid guess_max", {
-
   expect_error(
     read_excel(test_sheet("iris-excel-xlsx.xlsx"), guess_max = NA),
     "`guess_max` must be a positive integer"
@@ -57,7 +56,6 @@ test_that("read_excel catches invalid guess_max", {
 })
 
 test_that("read_excel catches invalid n_max", {
-
   expect_error(
     read_excel(test_sheet("iris-excel-xlsx.xlsx"), n_max = NA),
     "`n_max` must be a positive integer"

--- a/tests/testthat/test-richtext.R
+++ b/tests/testthat/test-richtext.R
@@ -4,11 +4,11 @@ test_that("rich text strings are handled in stringtable", {
   rt <- read_excel(test_sheet("richtext-coloured.xlsx"), col_names = FALSE)
 
   for (i in 1:4)
-    expect_equal(rt[[1,i]], "abcd")
+    expect_equal(rt[[1, i]], "abcd")
 
-  expect_equal(rt[[2,1]], "tvalrval1rval2")
+  expect_equal(rt[[2, 1]], "tvalrval1rval2")
   for (i in 2:4)
-    expect_equal(rt[[2,i]], "rval1rval2")
+    expect_equal(rt[[2, i]], "rval1rval2")
 })
 
 test_that("rich text inside inlineStr", {
@@ -22,7 +22,7 @@ test_that("rich text inside inlineStr", {
 
 test_that("strings containing escaped hexcodes are read", {
   df <- read_excel(test_sheet("new_line_errors.xlsx"))
-  expect_false(grepl("_x000D_", df[1,1]))
-  expect_equal(substring(df[1,1],20,21), "\u000d\r")
-  expect_equal(substring(df[2,1],11,19), "\"_x000D_\"")
+  expect_false(grepl("_x000D_", df[1, 1]))
+  expect_equal(substring(df[1, 1], 20, 21), "\u000d\r")
+  expect_equal(substring(df[2, 1], 11, 19), "\"_x000D_\"")
 })

--- a/tests/testthat/test-sheets.R
+++ b/tests/testthat/test-sheets.R
@@ -46,11 +46,13 @@ test_that("sheet can be parsed out of range", {
 test_that("double specification of sheet generates message and range wins", {
   expect_message(
     double <-
-      read_excel(test_sheet("sheet-xml-lookup.xlsx"),
-                 sheet = "Asia", range = "Oceania!A1:A1"),
+      read_excel(
+        test_sheet("sheet-xml-lookup.xlsx"),
+        sheet = "Asia", range = "Oceania!A1:A1"
+      ),
     "Two values given for `sheet`. Using the `sheet` found in `range`"
   )
-  ref <- read_excel(test_sheet("sheet-xml-lookup.xlsx"),range = "Oceania!A1:A1")
+  ref <- read_excel(test_sheet("sheet-xml-lookup.xlsx"), range = "Oceania!A1:A1")
   expect_identical(double, ref)
 })
 

--- a/tests/testthat/test-trim-ws.R
+++ b/tests/testthat/test-trim-ws.R
@@ -21,10 +21,14 @@ test_that("trim_ws is default and it works", {
 
 test_that("trim_ws = FALSE preserves whitespace", {
   ## data
-  xls <- read_excel(test_sheet("whitespace-xls.xls"),
-                    col_names = FALSE, trim_ws = FALSE)
-  xlsx <- read_excel(test_sheet("whitespace-xlsx.xlsx"),
-                     col_names = FALSE, trim_ws = FALSE)
+  xls <- read_excel(
+    test_sheet("whitespace-xls.xls"),
+    col_names = FALSE, trim_ws = FALSE
+  )
+  xlsx <- read_excel(
+    test_sheet("whitespace-xlsx.xlsx"),
+    col_names = FALSE, trim_ws = FALSE
+  )
   expect_false(identical(xls[[1]], trimws(xls[[1]])))
   expect_false(identical(xlsx[[1]], trimws(xlsx[[1]])))
   ## I have a whitespace-only cell with contents: "\t   \t"
@@ -41,10 +45,14 @@ test_that("trim_ws = FALSE preserves whitespace", {
 })
 
 test_that("whitespace-flanked na strings match when trim_ws = TRUE", {
-  xls <- read_excel(test_sheet("whitespace-xls.xls"),
-                    sheet = "logical_and_NA", na = ":-)")
-  xlsx <- read_excel(test_sheet("whitespace-xlsx.xlsx"),
-                     sheet = "logical_and_NA", na = ":-)")
+  xls <- read_excel(
+    test_sheet("whitespace-xls.xls"),
+    sheet = "logical_and_NA", na = ":-)"
+  )
+  xlsx <- read_excel(
+    test_sheet("whitespace-xlsx.xlsx"),
+    sheet = "logical_and_NA", na = ":-)"
+  )
   expect_is(xls$numeric, "numeric")
   expect_is(xlsx$numeric, "numeric")
   expect_true(is.na(xls[[2, 1]]))
@@ -52,10 +60,14 @@ test_that("whitespace-flanked na strings match when trim_ws = TRUE", {
 })
 
 test_that("whitespace-flanked na strings do not match when trim_ws = FALSE", {
-  xls <- read_excel(test_sheet("whitespace-xls.xls"),
-                    sheet = "logical_and_NA", na = ":-)", trim_ws = FALSE)
-  xlsx <- read_excel(test_sheet("whitespace-xlsx.xlsx"),
-                     sheet = "logical_and_NA", na = ":-)", trim_ws = FALSE)
+  xls <- read_excel(
+    test_sheet("whitespace-xls.xls"),
+    sheet = "logical_and_NA", na = ":-)", trim_ws = FALSE
+  )
+  xlsx <- read_excel(
+    test_sheet("whitespace-xlsx.xlsx"),
+    sheet = "logical_and_NA", na = ":-)", trim_ws = FALSE
+  )
   expect_is(xls$numeric, "character")
   expect_is(xlsx$numeric, "character")
   expect_identical(xls[[2, 1]], "  :-)  ")


### PR DESCRIPTION
Resolves #357

Recall previous discussion about name repair, that lead to `tibble::set_tidy_names()`: https://github.com/tidyverse/tibble/issues/217

I would really like to make this change. And I predict that revdep checks will reveal few/no problems with this move in *packages*.

But I also know from the previous release that any change here generates a lot of fretting and issues, as people have scripts that are hardwired to whatever the previous name repair strategy was. It also always brings up the usual suggestions to clean up nonsyntactic names. Quoting @hadley from thread linked above:

> I'm not sure what we should do with respect to backward compatibility. I suspect few packages depend on this behaviour; it's going to be more user code. I think as long as there's a clear way to get to the old behaviour it shouldn't cause much hassle (especially since we're now describing what's happening)

Thoughts on whether and how to proceed?

