### PR TITLE
Switch to tibble::set_tidy_names() from tibble::repair_names()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ LinkingTo: Rcpp
 Imports:
     cellranger,
     Rcpp (>= 0.12.12),
-    tibble (>= 1.1)
+    tibble (>= 1.3.1)
 Suggests:
     covr,
     knitr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # readxl 1.1.0.9000
 
+* Missing or duplicated column names are now repaired with `tibble::set_tidy_names()` in `read_excel()` and friends. `set_tidy_names()` is intended to encourage name repair that is more principled and consistent, across multiple tidyverse packages. Its design is discussed in [tidyverse/tibble#217](https://github.com/tidyverse/tibble/issues/217). (#357, #453)
+
+  - Example of change a user will see: consider a spreadsheet with three columns, one unnamed and two named `x`.
+  - Column names in readxl > 1.1.0: `..1`, `x..2`, `x..3`
+  - Column names in readxl <= 1.1.0: `X__1`, `x`, `x__1`
+
 # readxl 1.1.0
 
 * `read_excel()` and `excel_sheets()` associate a larger set of file extensions with xlsx and are better able to guess the format of a file with a nonstandard or missing extension. This is about deciding whether to treat a file as xls or xlsx. (#342, #411, #457)

--- a/R/read_excel.R
+++ b/R/read_excel.R
@@ -149,7 +149,7 @@ read_excel_ <- function(path, sheet = NULL, range = NULL,
   col_types <- check_col_types(col_types)
   guess_max <- check_guess_max(guess_max)
   trim_ws <- check_bool(trim_ws, "trim_ws")
-  tibble::repair_names(
+  tibble::set_tidy_names(
     tibble::as_tibble(
       read_fun(
         path = path, sheet_i = sheet,
@@ -158,8 +158,7 @@ read_excel_ <- function(path, sheet = NULL, range = NULL,
         na = na, trim_ws = trim_ws, guess_max = guess_max
       ),
       validate = FALSE
-    ),
-    prefix = "X", sep = "__"
+    )
   )
 }
 

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -5,3 +5,7 @@ test_sheet <- function(fname) rprojroot::find_testthat_root_file("sheets", fname
 ## once https://github.com/hadley/testthat/commit/c83aba9 is on CRAN
 ## can use testthat::test_path() for this, i.e.,
 # test_sheet <- function(fname) testthat::test_path("sheets", fname)
+
+expect_error_free <- function(...) {
+  expect_error(..., regexp = NA)
+}

--- a/tests/testthat/test-col-names.R
+++ b/tests/testthat/test-col-names.R
@@ -46,16 +46,16 @@ test_that("col_names = FALSE mimics missing column names [xls]", {
 
 test_that("missing column names are populated", {
   df <- read_excel(test_sheet("unnamed-duplicated-columns.xlsx"))
-  expect_identical(names(df)[c(1, 3)], c("X__1", "X__2"))
+  expect_identical(names(df)[c(1, 3)], c("..1", "..3"))
   df <- read_excel(test_sheet("unnamed-duplicated-columns.xls"))
-  expect_identical(names(df)[c(1, 3)], c("X__1", "X__2"))
+  expect_identical(names(df)[c(1, 3)], c("..1", "..3"))
 })
 
 test_that("column names are de-duplicated", {
   df <- read_excel(test_sheet("unnamed-duplicated-columns.xlsx"))
-  expect_identical(names(df)[4], "var2__1")
+  expect_identical(names(df)[4], "var2..4")
   df <- read_excel(test_sheet("unnamed-duplicated-columns.xls"))
-  expect_identical(names(df)[4], "var2__1")
+  expect_identical(names(df)[4], "var2..4")
 })
 
 test_that("wrong length column names are rejected", {

--- a/tests/testthat/test-compatibility.R
+++ b/tests/testthat/test-compatibility.R
@@ -61,7 +61,7 @@ test_that("formula cell with no v node does not cause crash", {
 ## LAPD uses a tool to produce xlsx that implements the minimal SpreadsheetML
 ## package structure described on pp65-66 of ECMA 5th edition
 test_that("we can read LAPD arrest sheets", {
-  expect_silent(
+  expect_error_free(
     lapd <- read_excel(test_sheet("los-angeles-arrests-xlsx.xlsx"), skip = 2)
   )
   expect_identical(dim(lapd), c(193L, 36L))

--- a/tests/testthat/test-missing-values.R
+++ b/tests/testthat/test-missing-values.R
@@ -120,7 +120,7 @@ test_that("empty (styled) cells are not loaded, but can survive as NA [xlsx]", {
     var1 = c("val1,1", "val2,1", "val3,1"),
     var2 = NA,
     var3 = c("aa", "bb", "cc"),
-    X__1 = NA,
+     ..4 = NA,
     var5 = c(1, 2, 3)
   )
   expect_equal(out, df)
@@ -132,7 +132,7 @@ test_that("empty (styled) cells are not loaded, but can survive as NA [xls]", {
     var1 = c("val1,1", "val2,1", "val3,1"),
     var2 = NA,
     var3 = c("aa", "bb", "cc"),
-    X__1 = NA,
+     ..4 = NA,
     var5 = c(1, 2, 3)
   )
   expect_equal(out, df)


### PR DESCRIPTION
Resolves #357

Recall previous discussion about name repair, that lead to `tibble::set_tidy_names()`: https://github.com/tidyverse/tibble/issues/217

I would really like to make this change. And I predict that revdep checks will reveal few/no problems with this move in *packages*.

But I also know from the previous release that any change here generates a lot of upset and issues, as people have scripts that are hardwired to whatever the previous name repair strategy was. It also always brings up the usual suggestions to clean up nonsyntactic names. Quoting @hadley from thread linked above:

> I'm not sure what we should do with respect to backward compatibility. I suspect few packages depend on this behaviour; it's going to be more user code. I think as long as there's a clear way to get to the old behaviour it shouldn't cause much hassle (especially since we're now describing what's happening)

Thoughts on whether and how to proceed?
