### PR TITLE
Use a pragma to silence the C99 extensions warnings

### DIFF
--- a/src/ColSpec.h
+++ b/src/ColSpec.h
@@ -1,6 +1,9 @@
 #ifndef READXL_COLSPEC_
 #define READXL_COLSPEC_
 
+#pragma GCC diagnostic ignored "-Wc99-extensions"
+#pragma clang diagnostic ignored "-Wc99-extensions"
+
 #include <Rcpp.h>
 #include <libxls/xls.h>
 #include "StringSet.h"

--- a/src/XlsWorkBook.cpp
+++ b/src/XlsWorkBook.cpp
@@ -1,4 +1,8 @@
 #include <Rcpp.h>
+
+#pragma GCC diagnostic ignored "-Wc99-extensions"
+#pragma clang diagnostic ignored "-Wc99-extensions"
+
 #include "XlsWorkBook.h"
 using namespace Rcpp;
 

--- a/src/XlsWorkSheet.cpp
+++ b/src/XlsWorkSheet.cpp
@@ -1,7 +1,7 @@
 #include <Rcpp.h>
 
-#include "XlsWorkSheet.h"
 #include "ColSpec.h"
+#include "XlsWorkSheet.h"
 #include <libxls/xls.h>
 using namespace Rcpp;
 

--- a/src/XlsxWorkSheet.cpp
+++ b/src/XlsxWorkSheet.cpp
@@ -1,6 +1,6 @@
 #include <Rcpp.h>
-#include "XlsxWorkSheet.h"
 #include "ColSpec.h"
+#include "XlsxWorkSheet.h"
 #include "utils.h"
 using namespace Rcpp;
 

--- a/src/libxls/xlsstruct.h
+++ b/src/libxls/xlsstruct.h
@@ -33,6 +33,10 @@
 #ifndef XLS_STRUCT_INC
 #define XLS_STRUCT_INC
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "libxls/ole.h"
 
 #define XLS_RECORD_EOF          0x000A
@@ -194,7 +198,7 @@ typedef struct MULRK
 	struct {
 		WORD	xf;
 		DWORD_UA value;
-	}		rk[1]; // readxl
+	}		rk[];
 	//WORD	last_col;
 }
 MULRK;
@@ -203,7 +207,7 @@ typedef struct MULBLANK
 {
     WORD	row;
     WORD	col;
-    WORD	xf[1]; // readxl
+    WORD	xf[];
 	//WORD	last_col;
 }
 MULBLANK;
@@ -240,7 +244,7 @@ typedef struct SST
 {
     DWORD	num;
     DWORD	numofstr;
-    BYTE	strings[0];
+    BYTE	strings[];
 }
 SST;
 
@@ -312,7 +316,7 @@ typedef struct FONT
     BYTE	family;
     BYTE	charset;
     BYTE	notused;
-    char    name[1]; // readxl
+    char    name[];
 }
 FONT;
 
@@ -529,5 +533,9 @@ typedef struct xls_summaryInfo
 xlsSummaryInfo;
 
 typedef void (*xls_formula_handler)(WORD bof, WORD len, BYTE *formula);
+
+#ifdef __cplusplus
+} // extern c block
+#endif
 
 #endif

--- a/src/xls.c
+++ b/src/xls.c
@@ -90,7 +90,7 @@ typedef struct {
 	uint32_t		os;
 	uint32_t		format[4];
 	uint32_t		count;
-	sectionList		secList[1]; // readxl
+	sectionList		secList[];
 } header;
 
 typedef struct {
@@ -101,12 +101,12 @@ typedef struct {
 typedef struct {
 	uint32_t		length;
 	uint32_t		numProperties;
-	propertyList	properties[1];  // readxl
+	propertyList	properties[];
 } sectionHeader;
 
 typedef struct {
 	uint32_t		propertyID;
-	uint32_t		data[1];  // readxl
+	uint32_t		data[];
 } property;
 
 #pragma pack(pop)
@@ -785,7 +785,7 @@ xls_error_t xls_parseWorkBook(xlsWorkBook* pWB)
 		if(xls_debug > 10) {
 			printf("READ WORKBOOK filePos=%ld\n",  (long)pWB->filepos);
 			printf("  OLE: start=%d pos=%zd size=%zd fatPos=%zu\n",
-                    pWB->olestr->start, pWB->olestr->pos, pWB->olestr->size, pWB->olestr->fatpos); 
+                    pWB->olestr->start, pWB->olestr->pos, pWB->olestr->size, pWB->olestr->fatpos);
 		}
 
         if (ole2_read(&bof1, 1, 4, pWB->olestr) != 4) {
@@ -1018,7 +1018,7 @@ xls_error_t xls_parseWorkBook(xlsWorkBook* pWB)
 				printf("   mode: 0x%x\n", pWB->is1904);
 			}
 			break;
-		
+
 		case XLS_RECORD_DEFINEDNAME:
 			if(xls_debug) {
 				int i;
@@ -1027,7 +1027,7 @@ xls_error_t xls_parseWorkBook(xlsWorkBook* pWB)
 				printf("\n");
 			}
 			break;
-			
+
         default:
 			if(xls_debug)
 			{


### PR DESCRIPTION
This also reverts changing the flexible array members to single element
arrays.