### PR TITLE
Backout array hacks

### DIFF
--- a/src/libxls/xlsstruct.h
+++ b/src/libxls/xlsstruct.h
@@ -194,7 +194,7 @@ typedef struct MULRK
 	struct {
 		WORD	xf;
 		DWORD_UA value;
-	}		rk[1]; // readxl
+	}		rk[];
 	//WORD	last_col;
 }
 MULRK;
@@ -312,7 +312,7 @@ typedef struct FONT
     BYTE	family;
     BYTE	charset;
     BYTE	notused;
-    char    name[1]; // readxl
+    char    name[];
 }
 FONT;
 

--- a/src/libxls/xlsstruct.h
+++ b/src/libxls/xlsstruct.h
@@ -203,7 +203,7 @@ typedef struct MULBLANK
 {
     WORD	row;
     WORD	col;
-    WORD	xf[1]; // readxl
+    WORD	xf[];
 	//WORD	last_col;
 }
 MULBLANK;

--- a/src/xls.c
+++ b/src/xls.c
@@ -90,7 +90,7 @@ typedef struct {
 	uint32_t		os;
 	uint32_t		format[4];
 	uint32_t		count;
-	sectionList		secList[1]; // readxl
+	sectionList		secList[0];
 } header;
 
 typedef struct {
@@ -101,12 +101,12 @@ typedef struct {
 typedef struct {
 	uint32_t		length;
 	uint32_t		numProperties;
-	propertyList	properties[1];  // readxl
+	propertyList	properties[0];
 } sectionHeader;
 
 typedef struct {
 	uint32_t		propertyID;
-	uint32_t		data[1];  // readxl
+	uint32_t		data[0];
 } property;
 
 #pragma pack(pop)


### PR DESCRIPTION
This is a version that removes all readxl workarounds re: zero size arrays and flexible array members.

It is looking increasingly likely that we must submit with some sort of NOTE and we are now choosing between compiler warnings like these:

```
./libxls/xlsstruct.h:126:10: warning: flexible array members are a C99 feature [-Wc99-extensions]
    char        name[];
                ^

./libxls/xlsstruct.h:243:18: warning: zero size arrays are an extension [-Wzero-length-array]
    BYTE        strings[0];
                        ^
```

or this NOTE:

```
Files which contain pragma(s) suppressing diagnostics:
  ‘src/ColSpec.h’ ‘src/XlsWorkBook.cpp’
```

associated with the solution in #459.