### PR TITLE
Make sure path is in native encoding

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,19 @@
 # readxl 1.1.0.9000
 
+## Breaking change
+
 * Missing or duplicated column names are now repaired with `tibble::set_tidy_names()` in `read_excel()` and friends. `set_tidy_names()` is intended to encourage name repair that is more principled and consistent, across multiple tidyverse packages. Its design is discussed in [tidyverse/tibble#217](https://github.com/tidyverse/tibble/issues/217). (#357, #453)
 
   - Example of change a user will see: consider a spreadsheet with three columns, one unnamed and two named `x`.
   - Column names in readxl > 1.1.0: `..1`, `x..2`, `x..3`
   - Column names in readxl <= 1.1.0: `X__1`, `x`, `x__1`
+  
+## Other changes
+
+* Path handling (#477):
+
+  - `.xls` paths are no longer normalized. (#476 xls)
+  - All paths are explicitly converted to the native encoding via `enc2native()`  (#370)
 
 # readxl 1.1.0
 

--- a/R/read_excel.R
+++ b/R/read_excel.R
@@ -152,7 +152,7 @@ read_excel_ <- function(path, sheet = NULL, range = NULL,
   tibble::set_tidy_names(
     tibble::as_tibble(
       read_fun(
-        path = path, sheet_i = sheet,
+        path = enc2native(path), sheet_i = sheet,
         limits = limits, shim = shim,
         col_names = col_names, col_types = col_types,
         na = na, trim_ws = trim_ws, guess_max = guess_max

--- a/src/XlsWorkBook.h
+++ b/src/XlsWorkBook.h
@@ -6,13 +6,6 @@
 #include "ColSpec.h"
 #include "utils.h"
 
-inline std::string normalizePath(std::string path) {
-  Rcpp::Environment baseEnv = Rcpp::Environment::base_env();
-  Rcpp::Function normalizePath = baseEnv["normalizePath"];
-  Rcpp::Function enc2native = baseEnv["enc2native"];
-  return Rcpp::as<std::string>(enc2native(normalizePath(path, "/", true)));
-}
-
 class XlsWorkBook {
 
   // common to Xls[x]WorkBook
@@ -27,7 +20,7 @@ class XlsWorkBook {
 public:
 
   XlsWorkBook(const std::string& path) {
-    path_ = normalizePath(path);
+    path_ = path;
 
     xls::xlsWorkBook* pWB_ = xls::xls_open(path_.c_str(), "UTF-8");
     if (pWB_ == NULL) {

--- a/src/XlsWorkBook.h
+++ b/src/XlsWorkBook.h
@@ -26,7 +26,8 @@ class XlsWorkBook {
 public:
 
   XlsWorkBook(const std::string& path) {
-    path_ = normalizePath(path);
+    //path_ = normalizePath(path);
+    path_ = path;
 
     xls::xlsWorkBook* pWB_ = xls::xls_open(path_.c_str(), "UTF-8");
     if (pWB_ == NULL) {

--- a/src/XlsWorkBook.h
+++ b/src/XlsWorkBook.h
@@ -9,7 +9,8 @@
 inline std::string normalizePath(std::string path) {
   Rcpp::Environment baseEnv = Rcpp::Environment::base_env();
   Rcpp::Function normalizePath = baseEnv["normalizePath"];
-  return Rcpp::as<std::string>(normalizePath(path, "/", true));
+  Rcpp::Function enc2native = baseEnv["enc2native"];
+  return Rcpp::as<std::string>(enc2native(normalizePath(path, "/", true)));
 }
 
 class XlsWorkBook {
@@ -26,8 +27,7 @@ class XlsWorkBook {
 public:
 
   XlsWorkBook(const std::string& path) {
-    //path_ = normalizePath(path);
-    path_ = path;
+    path_ = normalizePath(path);
 
     xls::xlsWorkBook* pWB_ = xls::xls_open(path_.c_str(), "UTF-8");
     if (pWB_ == NULL) {

--- a/tests/testthat/test-read-excel.R
+++ b/tests/testthat/test-read-excel.R
@@ -96,11 +96,15 @@ test_that("trim_ws must be a logical", {
 
 ## https://github.com/tidyverse/readxl/issues/476
 test_that("non-ASCII xls filenames can be read", {
-  ## chosen to be non-ASCII but representable in Windows-1252 codepage
-  ## a-grave e-diaeresis Eth + '.xls'
+  skip_on_cran()
+  ## chosen to be non-ASCII but
+  ## [1] representable in Windows-1252 and
+  ## [2] not any of the few differences between Windows-1252 and ISO-8859-1
+  ## a-grave + e-diaeresis  + Eth + '.xls'
   filename <- "\u00C0\u00CB\u00D0\u002E\u0078\u006C\u0073"
   tricky_file <- file.path(tempdir(), filename)
   file.copy(test_sheet("mtcars.xls"), tricky_file)
+  expect_true(file.exists(tricky_file))
   on.exit(file.remove(tricky_file))
   expect_error_free(read_xls(tricky_file))
 })

--- a/tests/testthat/test-read-excel.R
+++ b/tests/testthat/test-read-excel.R
@@ -93,3 +93,14 @@ test_that("trim_ws must be a logical", {
     "`trim_ws` must be either TRUE or FALSE"
   )
 })
+
+## https://github.com/tidyverse/readxl/issues/476
+test_that("non-ASCII xls filenames can be read", {
+  ## chosen to be non-ASCII but representable in Windows-1252 codepage
+  ## a-grave e-diaeresis Eth + '.xls'
+  filename <- "\u00C0\u00CB\u00D0\u002E\u0078\u006C\u0073"
+  tricky_file <- file.path(tempdir(), filename)
+  file.copy(test_sheet("mtcars.xls"), tricky_file)
+  on.exit(file.remove(tricky_file))
+  expect_error_free(read_xls(tricky_file))
+})

--- a/tests/testthat/test-read-excel.R
+++ b/tests/testthat/test-read-excel.R
@@ -94,17 +94,24 @@ test_that("trim_ws must be a logical", {
   )
 })
 
-## https://github.com/tidyverse/readxl/issues/476
-test_that("non-ASCII xls filenames can be read", {
+## xlsx: https://github.com/tidyverse/readxl/issues/370
+## xls:  https://github.com/tidyverse/readxl/issues/476
+test_that("non-ASCII filenames can be read", {
   skip_on_cran()
   ## chosen to be non-ASCII but
   ## [1] representable in Windows-1252 and
   ## [2] not any of the few differences between Windows-1252 and ISO-8859-1
-  ## a-grave + e-diaeresis  + Eth + '.xls'
-  filename <- "\u00C0\u00CB\u00D0\u002E\u0078\u006C\u0073"
-  tricky_file <- file.path(tempdir(), filename)
-  file.copy(test_sheet("mtcars.xls"), tricky_file)
-  expect_true(file.exists(tricky_file))
-  on.exit(file.remove(tricky_file))
-  expect_error_free(read_xls(tricky_file))
+  ## a-grave + e-diaeresis  + Eth + '.xls[x]'
+  xls_filename <- "\u00C0\u00CB\u00D0\u002E\u0078\u006C\u0073"
+  xlsx_filename <- "\u00C0\u00CB\u00D0\u002E\u0078\u006C\u0073\u0078"
+  tricky_xls_file <- file.path(tempdir(), xls_filename)
+  tricky_xlsx_file <- file.path(tempdir(), xlsx_filename)
+  file.copy(test_sheet("list_type.xls"), tricky_xls_file)
+  file.copy(test_sheet("list_type.xlsx"), tricky_xlsx_file)
+  expect_true(file.exists(tricky_xls_file))
+  expect_true(file.exists(tricky_xlsx_file))
+  on.exit(file.remove(tricky_xls_file))
+  on.exit(file.remove(tricky_xlsx_file))
+  expect_error_free(read_xls(tricky_xls_file))
+  expect_error_free(read_xlsx(tricky_xlsx_file))
 })


### PR DESCRIPTION
Fixes #476 CP1251 char set in file name

Fixes #370 read_excel on Windows fails to open a file from a UTF-8 encoded path containing special characters

This is a new problem seen with R 3.5, we believe as a result of measures taken in response to [Bug 17120 ](https://bugs.r-project.org/bugzilla3/show_bug.cgi?id=17120):

In a non-UTF-8 locale (basically Windows?), `path.expand()` returns a UTF-8 encoded path, even for non UTF-8 input. readxl pre-processes xls paths via `normalizePath()`, which calls `path.expand()`. And then libxls uses `fopen()`, which expects the path in the native encoding.

We have two choices:

  1. Stop using `normalizePath()` on xls files. It's not clear to me why we do this. This code goes back to Day 3 of readxl development, in 2015 fc076c463dca90407e03a8c988df6c65936051bb. The history doesn't indicate if there is a reason to use `normalizePath()`. I explored "stop calling `normalizePath()`" in 945178d41dbef4b02a0ce56c7fffc1793d2eaed6, which passes tests. If we choose this, I will obviously remove more even code vs. comment it out.
  2. Keep using `normalizePath()` on xls files, but process immediately with `enc2native()`.  Explored in 8a8c06136c9254b029368c24dc34915f49af6d0c, which also passes tests.

Either way, I think we should consider incorporating the new test. However I decided `skip_on_cran()` might be wise.