### PR TITLE
libxls gcc5/6/7 fix

### DIFF
--- a/src/libxls/ole.h
+++ b/src/libxls/ole.h
@@ -33,9 +33,12 @@
 #ifndef OLE_INCLUDE
 #define OLE_INCLUDE
 
-#define _XOPEN_SOURCE 500
-
 #include <stdio.h>			// FILE *
+
+#ifndef _XOPEN_SOURCE
+#define _XOPEN_SOURCE 500
+#endif
+#include <sys/types.h>
 
 #include "libxls/xlstypes.h"
 

--- a/src/libxls/ole.h
+++ b/src/libxls/ole.h
@@ -33,6 +33,8 @@
 #ifndef OLE_INCLUDE
 #define OLE_INCLUDE
 
+#define _XOPEN_SOURCE 500
+
 #include <stdio.h>			// FILE *
 
 #include "libxls/xlstypes.h"


### PR DESCRIPTION
Wasn't compiling because `ssize_t` was undefined.

```
gcc [...]   -fpic  -O2 -march=native -std=c99  -c endian.c -o endian.o
In file included from ./libxls/xlsstruct.h:40:0,
                 from libxls/endian.h:30,
                 from endian.c:33:
./libxls/ole.h:174:1: error: unknown type name ‘ssize_t’
 extern ssize_t ole2_read(void* buf,size_t size,size_t count,OLE2Stream* olest);
 ^
make: *** [endian.o] Error 1
ERROR: compilation failed for package ‘readxl’
```

`ssize_t` should be defined in `stdio.h`, according to [POSIX 2008](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/stdio.h.html#tag_13_49), which is included already and the compile flag `_XOPEN_SOURCE` was set to 700, but according to [POSIX 2004](http://pubs.opengroup.org/onlinepubs/9699919799/) and [POSIX 1995](http://pubs.opengroup.org/onlinepubs/007908799/) it is only defined in `sys/types.h`. Including that fixed the compile error.

If undefined, I further set `_XOPEN_SOURCE 500`, just in case.