### PR TITLE
Normalize all paths, prior conversion to native encoding

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# readxl 1.1.0.9000
+# readxl *development version*
 
 * readxl has a new vignette on reading excel files with multiple header rows, contributed by @apreshill. (#486, #492)
 
@@ -12,10 +12,9 @@
   
 ## Other changes
 
-* Path handling (#477):
+* Path handling:
 
-  - `.xls` paths are no longer normalized. (#476 xls)
-  - All paths are explicitly converted to the native encoding via `enc2native()`  (#370)
+  - All paths are passed through `normalizePath()` (#498, #499, new behaviour for xlsx but not xls) and `enc2native()` (#370).
 
 # readxl 1.1.0
 

--- a/R/read_excel.R
+++ b/R/read_excel.R
@@ -152,7 +152,7 @@ read_excel_ <- function(path, sheet = NULL, range = NULL,
   tibble::set_tidy_names(
     tibble::as_tibble(
       read_fun(
-        path = enc2native(path), sheet_i = sheet,
+        path = enc2native(normalizePath(path)), sheet_i = sheet,
         limits = limits, shim = shim,
         col_names = col_names, col_types = col_types,
         na = na, trim_ws = trim_ws, guess_max = guess_max


### PR DESCRIPTION
Fixes #498

Prior to b10a1a80fba57e1e7e515b78f64acf62fd75843a, all xls paths were normalized, but we didn't know exactly why. In b10a1a80fba57e1e7e515b78f64acf62fd75843a, I stopped normalizing xls paths, while solving an unrelated path encoding problem presented by R 3.5.

In discussion around #477, @jimhester said:

"I think doing `enc2native(normalizePath())` on the R side for both xls and xlsx seems the best option."

I am now taking this wise advice.