### PR TITLE
Adapt to tibble v1.4.99.* and ruminate on name repair

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,7 +46,7 @@ BugReports: https://github.com/tidyverse/readxl/issues
 Imports:
     cellranger,
     Rcpp (>= 0.12.12),
-    tibble (>= 1.3.1)
+    tibble (>= 1.4.99.9003)
 Suggests:
     covr,
     knitr,
@@ -62,3 +62,5 @@ LazyData: true
 Note: libxls-SHA d2726da
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 6.1.0
+Remotes:  
+    tidyverse/tibble

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,6 +46,7 @@ BugReports: https://github.com/tidyverse/readxl/issues
 Imports:
     cellranger,
     Rcpp (>= 0.12.12),
+    rlang,
     tibble (>= 1.4.99.9003)
 Suggests:
     covr,
@@ -57,10 +58,10 @@ LinkingTo:
     Rcpp
 VignetteBuilder: 
     knitr
+Remotes: 
+    tidyverse/tibble
 Encoding: UTF-8
 LazyData: true
 Note: libxls-SHA d2726da
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 6.1.0
-Remotes:  
-    tidyverse/tibble

--- a/R/utils.R
+++ b/R/utils.R
@@ -16,3 +16,7 @@ is_integerish <- function(x) {
 is_string <- function(x) {
   length(x) == 1 && is.character(x)
 }
+
+isFALSE <- function(x) {
+  is.logical(x) && length(x) == 1L && !is.na(x) && !x
+}

--- a/man/read_excel.Rd
+++ b/man/read_excel.Rd
@@ -8,15 +8,15 @@
 \usage{
 read_excel(path, sheet = NULL, range = NULL, col_names = TRUE,
   col_types = NULL, na = "", trim_ws = TRUE, skip = 0,
-  n_max = Inf, guess_max = min(1000, n_max))
+  n_max = Inf, guess_max = min(1000, n_max), .tidy_names = TRUE)
 
 read_xls(path, sheet = NULL, range = NULL, col_names = TRUE,
   col_types = NULL, na = "", trim_ws = TRUE, skip = 0,
-  n_max = Inf, guess_max = min(1000, n_max))
+  n_max = Inf, guess_max = min(1000, n_max), .tidy_names = TRUE)
 
 read_xlsx(path, sheet = NULL, range = NULL, col_names = TRUE,
   col_types = NULL, na = "", trim_ws = TRUE, skip = 0,
-  n_max = Inf, guess_max = min(1000, n_max))
+  n_max = Inf, guess_max = min(1000, n_max), .tidy_names = TRUE)
 }
 \arguments{
 \item{path}{Path to the xls/xlsx file.}
@@ -62,6 +62,15 @@ the returned tibble. Ignored if \code{range} is given.}
 
 \item{guess_max}{Maximum number of data rows to use for guessing column
 types.}
+
+\item{.tidy_names}{Treatment of invalid or duplicate column names:
+\itemize{
+\item \code{NULL}: default, throw an error if there are any missing or duplicated names,
+\item \code{FALSE}: deliberately request a tibble with invalid names,
+\item \code{TRUE}: apply \code{\link[=tidy_names]{tidy_names()}} to the names,
+\item a function: apply custom name repair (e.g., \code{.tidy_names = make.names}
+to get base R equivalence).
+}}
 }
 \value{
 A \link[tibble:tibble-package]{tibble}


### PR DESCRIPTION
For discussion. This PR

1. Adapts to the deprecation of `validate` in `as_tibble()`, i.e. it uses the new `.tidy_names` argument.
1. Intercepts `.tidy_names = TRUE` and `.tidy_names = some_function`, in order to capture the names before and after repair and return them in the `names_history` attribute of the returned tibble. This is in the same spirit as the "problems" reported by readr.

Reminder of what `.tidy_names` does:

https://github.com/tidyverse/tibble/blob/e816ba30ad227f7018a1868a66cc324d53589ffd/R/tibble.R#L26-L31

```
#' @param .tidy_names Treatment of invalid or duplicate column names:
#'   - `NULL`: default, throw an error if there are any missing or duplicated names,
#'   - `FALSE`: deliberately request a tibble with invalid names,
#'   - `TRUE`: apply [tidy_names()] to the names,
#'   - a function: apply custom name repair (e.g., `.tidy_names = make.names`
#'     to get base R equivalence).
```

This adds quite a lot of code and requires adding rlang to Imports (or copying code from tibble and rlang into readxl). There are some changes that could be made in tibble to make this easier (e.g. https://github.com/tidyverse/tibble/issues/462).

We could also decide to decline to report on name repair. If user wants such info, they should prevent name repair via `read_excel(..., .tidy_names = FALSE)` and do it themselves after the fact.

(I haven't fixed tests or NEWS yet ... but this does work, usage below.)

---

``` r
devtools::load_all(".")
#> Loading readxl

path <- test_sheet("unnamed-duplicated-columns.xlsx")

read_excel(path)
#> New names:
#> * `` -> ..1
#> * var2 -> var2..2
#> * `` -> ..3
#> * var2 -> var2..4
#> # A tibble: 2 x 4
#>     ..1 var2..2   ..3 var2..4
#>   <dbl> <chr>   <dbl> <chr>  
#> 1     1 a         1.1 aa     
#> 2     2 b         2.1 bb
read_excel(path, .tidy_names = TRUE) # the default
#> New names:
#> * `` -> ..1
#> * var2 -> var2..2
#> * `` -> ..3
#> * var2 -> var2..4
#> # A tibble: 2 x 4
#>     ..1 var2..2   ..3 var2..4
#>   <dbl> <chr>   <dbl> <chr>  
#> 1     1 a         1.1 aa     
#> 2     2 b         2.1 bb

read_excel(path, .tidy_names = NULL)
#> Error: Columns 1, 3 must be named.

read_excel(path, .tidy_names = FALSE)
#> # A tibble: 2 x 4
#>      `` var2     `` var2 
#>   <dbl> <chr> <dbl> <chr>
#> 1     1 a       1.1 aa   
#> 2     2 b       2.1 bb

## base R name repair
read_excel(path, .tidy_names = make.names)
#> # A tibble: 2 x 4
#>       X var2      X var2 
#>   <dbl> <chr> <dbl> <chr>
#> 1     1 a       1.1 aa   
#> 2     2 b       2.1 bb

## emulating behaviour of readxl v1.1.0
f <- function(x) {
  x <- tibble::repair_names(x, prefix = "X", sep = "__")
  names(x)
}
read_excel(path, .tidy_names = f)
#> # A tibble: 2 x 4
#>    X__1 X__2   X__3 X__4 
#>   <dbl> <chr> <dbl> <chr>
#> 1     1 a       1.1 aa   
#> 2     2 b       2.1 bb


## now let's look at names before / after
x <- read_excel(path, .tidy_names = TRUE)
#> New names:
#> * `` -> ..1
#> * var2 -> var2..2
#> * `` -> ..3
#> * var2 -> var2..4
attr(x, "names_history")
#> # A tibble: 4 x 2
#>   before after  
#>   <chr>  <chr>  
#> 1 ""     ..1    
#> 2 var2   var2..2
#> 3 ""     ..3    
#> 4 var2   var2..4

x <- read_excel(path, .tidy_names = make.names)
attr(x, "names_history")
#> # A tibble: 4 x 2
#>   before after
#>   <chr>  <chr>
#> 1 ""     X    
#> 2 var2   var2 
#> 3 ""     X    
#> 4 var2   var2

x <- read_excel(path, .tidy_names = f)
attr(x, "names_history")
#> # A tibble: 4 x 2
#>   before after
#>   <chr>  <chr>
#> 1 ""     X__1 
#> 2 var2   X__2 
#> 3 ""     X__3 
#> 4 var2   X__4
```

Created on 2018-08-21 by the [reprex package](http://reprex.tidyverse.org) (v0.2.0.9000).