### PR TITLE
Change rapidxml link to regular http

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Authors@R:
 Description: Import excel files into R. Supports '.xls' via the
     embedded 'libxls' C library <https://github.com/evanmiller/libxls> and
     '.xlsx' via the embedded 'RapidXML' C++ library
-    <https://rapidxml.sourceforge.net>.  Works on Windows, Mac and Linux
+    <http://rapidxml.sourceforge.net>.  Works on Windows, Mac and Linux
     without external dependencies.
 License: GPL-3
 URL: http://readxl.tidyverse.org,


### PR DESCRIPTION
* Fixes #502
* If we want to avoid having non-https links in DESCRIPTION, we could just remove the link there, since we mention it elsewhere