### PR TITLE
change warning for date before 1900-01-01

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -61,10 +61,15 @@ inline double dateRound(double dttm) {
 // Otherwise: do nothing
 inline double POSIXctFromSerial(double xlDate, bool is1904) {
   if (!is1904 && xlDate < 61) {
-    xlDate = (xlDate < 60) ? xlDate + 1 : -1;
+    if (xlDate < 60) {
+      xlDate = xlDate + 1;
+    } else {
+      Rcpp::warning("NA inserted for impossible 1900-02-29 datetime");
+      return NA_REAL;
+    }
   }
   if (xlDate < 0) {
-    Rcpp::warning("NA inserted for impossible 1900-02-29 datetime");
+    Rcpp::warning("NA inserted for date before 1900-01-01 not supported in excel");
     return NA_REAL;
   } else {
     return dateRound((xlDate - dateOffset(is1904)) * 86400);


### PR DESCRIPTION
This fixes #551. It is based on a research I made for investigating #547 so I find it useful to share, in case this correspond to how you would have it fixed it. 

I have just added a specific warning for 1900-02-29 and a general one for dates before 1900-01-01 that do not exist in excel. 

I wanted to add some test in `test-dates.R` but not sure how to do that for those date that do not exist in excel. It is also not easy because I am on an European Excel and it does not behave like english one. (If I open `test_sheet("dates-leap-year-1900-xlsx.xlsx")` in Excel, it does not behave as expected). 

Please tell me if you think I can add some anyway. 