### PR TITLE
List and filter sheets

### DIFF
--- a/R/excel-sheets.R
+++ b/R/excel-sheets.R
@@ -1,20 +1,49 @@
-#' List all sheets in an excel spreadsheet
+#' List sheets in an excel spreadsheet
 #'
 #' @inheritParams read_excel
+#' @param glob A wildcard to filter sheets.
+#' @param regexp A regular expression to filter sheets.
 #' @export
 #' @examples
 #' excel_sheets(readxl_example("datasets.xlsx"))
 #' excel_sheets(readxl_example("datasets.xls"))
 #'
+#' # Filter sheets using certain criteria
+#' excel_sheets(readxl_example("datasets.xls"), glob = "??i*")
+#' excel_sheets(readxl_example("datasets.xls"), regexp = "(r|e)s$")
+#'
 #' # To load all sheets in a workbook, use lapply
 #' path <- readxl_example("datasets.xls")
 #' lapply(excel_sheets(path), read_excel, path = path)
-excel_sheets <- function(path) {
+excel_sheets <- function(path, glob = NULL, regexp = NULL) {
   path <- check_file(path)
   format <- check_format(path)
 
-  switch(format,
+  sheets <- switch(format,
     xls = xls_sheets(path),
     xlsx = xlsx_sheets(path)
   )
+
+  if (!is.null(glob)) {
+    if (!is_string(glob)) {
+      stop("`glob` must be a string.", call. = FALSE)
+    }
+    if (!is.null(regexp)) {
+      stop("use either `glob` or `regexp`, not both.", call. = FALSE)
+    }
+    regexp <- utils::glob2rx(glob)
+  }
+
+  if (!is.null(regexp)) {
+    if (!is_string(regexp)) {
+      stop("`regexp` must be a string.", call. = FALSE)
+    }
+    sheets <- grep(x = sheets, pattern = regexp, value = TRUE)
+  }
+
+  if (length(sheets) == 0) {
+    stop("can not find sheets with the specified criteria.", call. = FALSE)
+  }
+
+  return(sheets)
 }

--- a/man/excel_sheets.Rd
+++ b/man/excel_sheets.Rd
@@ -2,19 +2,27 @@
 % Please edit documentation in R/excel-sheets.R
 \name{excel_sheets}
 \alias{excel_sheets}
-\title{List all sheets in an excel spreadsheet}
+\title{List sheets in an excel spreadsheet}
 \usage{
-excel_sheets(path)
+excel_sheets(path, glob = NULL, regexp = NULL)
 }
 \arguments{
 \item{path}{Path to the xls/xlsx file.}
+
+\item{glob}{A wildcard to filter sheets.}
+
+\item{regexp}{A regular expression to filter sheets.}
 }
 \description{
-List all sheets in an excel spreadsheet
+List sheets in an excel spreadsheet
 }
 \examples{
 excel_sheets(readxl_example("datasets.xlsx"))
 excel_sheets(readxl_example("datasets.xls"))
+
+# Filter sheets using certain criteria
+excel_sheets(readxl_example("datasets.xls"), glob = "??i*")
+excel_sheets(readxl_example("datasets.xls"), regexp = "(r|e)s$")
 
 # To load all sheets in a workbook, use lapply
 path <- readxl_example("datasets.xls")

--- a/tests/testthat/test-excel-sheets.R
+++ b/tests/testthat/test-excel-sheets.R
@@ -1,0 +1,30 @@
+context("excel_sheets")
+
+test_that("non-existent file throws error", {
+  expect_error(excel_sheets("foo"), "`path` does not exist")
+})
+
+test_that("detected sheets are correct", {
+  expect_identical(excel_sheets(test_sheet("blanks.xls")), c("different_rows", "same_row_first", "same_row_middle"))
+})
+
+test_that("invalid pattern throws error", {
+  expect_error(excel_sheets(test_sheet("geometry.xlsx"), glob = 123), "`glob` must be a string.")
+  expect_error(excel_sheets(test_sheet("geometry.xlsx"), glob = TRUE), "`glob` must be a string.")
+  expect_error(excel_sheets(test_sheet("geometry.xlsx"), glob = c("this", "that")), "`glob` must be a string.")
+  expect_error(excel_sheets(test_sheet("geometry.xlsx"), glob = "nothing"), "can not find sheets with the specified criteria.")
+  expect_error(excel_sheets(test_sheet("geometry.xlsx"), regexp = 123), "`regexp` must be a string.")
+  expect_error(excel_sheets(test_sheet("geometry.xlsx"), regexp = TRUE), "`regexp` must be a string.")
+  expect_error(excel_sheets(test_sheet("geometry.xlsx"), regexp = c("this", "that")), "`regexp` must be a string.")
+  expect_error(excel_sheets(test_sheet("geometry.xlsx"), regexp = "nothing"), "can not find sheets with the specified criteria.")
+  expect_error(excel_sheets(test_sheet("geometry.xlsx"), glob = "this", regexp = "that"), "use either `glob` or `regexp`, not both.")
+})
+
+test_that("filtering is working", {
+  expect_identical(excel_sheets(test_sheet("geometry.xlsx"), glob = "warn*"), c("warning_B6", "warning_AT6", "warning_AKE6"))
+  expect_identical(excel_sheets(test_sheet("geometry.xlsx"), glob = "warning*"), c("warning_B6", "warning_AT6", "warning_AKE6"))
+  expect_identical(excel_sheets(test_sheet("geometry.xlsx"), regexp =  "^warn"), c("warning_B6", "warning_AT6", "warning_AKE6"))
+  expect_identical(excel_sheets(test_sheet("geometry.xlsx"), regexp =  "_"), c("warning_B6", "warning_AT6", "warning_AKE6"))
+  expect_identical(excel_sheets(test_sheet("geometry.xlsx"), regexp =  "^[A-Z]"), "Sheet1")
+  expect_identical(excel_sheets(test_sheet("blanks.xlsx"), regexp =  "_row_"), c("same_row_first", "same_row_middle"))
+})


### PR DESCRIPTION
Hi,

I propose a functionality to filter excel sheets by using wild card or regular expression. For example:

```r
excel_sheets(readxl_example("datasets.xlsx"))
#> "iris"     "mtcars"   "chickwts" "quakes"  
excel_sheets(readxl_example("datasets.xlsx"), glob = "??i*")
#> "iris"     "chickwts"
excel_sheets(readxl_example("datasets.xlsx"), regexp = "(r|e)s$")
#> "mtcars" "quakes"
```

The purpose is to make it easier for user to pick certain sheets to be read simultaneously using `lapply()` or `map()`. Any suggestion is much appreciated!

Regards,

Aswan