### PR TITLE
Add lock bot.

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,7 +1,7 @@
 # Configuration for lock-threads - https://github.com/dessant/lock-threads
 
 # Number of days of inactivity before a closed issue or pull request is locked
-daysUntilLock: 180
+daysUntilLock: 365
 
 # Issues and pull requests with these labels will not be locked. Set to `[]` to disable
 exemptLabels: []

--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,0 +1,34 @@
+# Configuration for lock-threads - https://github.com/dessant/lock-threads
+
+# Number of days of inactivity before a closed issue or pull request is locked
+daysUntilLock: 180
+
+# Issues and pull requests with these labels will not be locked. Set to `[]` to disable
+exemptLabels: []
+
+# Label to add before locking, such as `outdated`. Set to `false` to disable
+lockLabel: false
+
+# Stop lockbot from closing as "resolved"
+setLockReason: false
+
+# Comment to post before locking. Set to `false` to disable
+lockComment: false
+
+# TODO: after initial round of locking, use comment below
+# lockComment: >
+#   This old issue has been automatically locked. If you believe you
+#   have found a related problem, please file a new issue (with reprex)
+#   and link to this issue. <https://reprex.tidyverse.org/>
+
+# Limit to only `issues` or `pulls`
+only: issues
+
+# Optionally, specify configuration settings just for `issues` or `pulls`
+# issues:
+#   exemptLabels:
+#     - help-wanted
+#   lockLabel: outdated
+
+# pulls:
+#   daysUntilLock: 30


### PR DESCRIPTION
* Fixes #585.

_n.b._ I've disabled the accompanying comment for the initial round of locks to reduce spam (à la https://github.com/tidyverse/readr/commit/17e51ca83ee133a5eaddb8359c8525d204bbd33b#diff-7761990043d6a34d155f65206eb35214 ). Once the initial round of locks has gone through, I'll enable the message, and switch `daysUntilLock` to 180.