### PR TITLE
Only round to the millisecond level

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -40,14 +40,14 @@ inline double dateOffset(bool is1904) {
 }
 
 // this is sort of horrible
-// convert serial date to decimilliseconds
+// convert serial date to milliseconds
 // use well-known hack to round to nearest integer w/o C++11 or boost, e.g.
 // http://stackoverflow.com/questions/485525/round-for-float-in-c
 // convert back to serial date
 inline double dateRound(double dttm) {
-  double ms = dttm * 10000;
+  double ms = dttm * 1000;
   ms = (ms >= 0.0 ? std::floor(ms + 0.5) : std::ceil(ms - 0.5));
-  return ms / 10000;
+  return ms / 1000;
 }
 
 // this is even more horrible


### PR DESCRIPTION
Closes #481

I'm not sure we can rely on >millisecond resolution with excel dates. I think that the most you can print them in the cell at is a millisecond resolution, so maybe we could call that the cutoff.

This old discussion says that you can technically input any fractional time, but you can only ever format up to milliseconds. 

"Although h:mm:ss.000 is the most precise custom format supported and recognized for data entry, we can actually input any fractional time."
http://www.tech-archive.net/Archive/Excel/microsoft.public.excel.misc/2009-03/msg04040.html

Before:

``` r
library(readxl)

tmp <- tempfile()
path <- "https://github.com/tidyverse/readxl/files/2008644/test_case.xlsx"
download.file(path, tmp)

df <- readxl::read_excel(tmp)

df[20:30,]
#> # A tibble: 11 x 1
#>    date_time          
#>    <dttm>             
#>  1 2017-10-10 19:00:00
#>  2 2017-10-10 20:00:00
#>  3 2017-10-10 21:00:00
#>  4 2017-10-10 22:00:00
#>  5 2017-10-10 23:00:00
#>  6 2017-10-10 23:59:59
#>  7 2017-10-11 00:59:59
#>  8 2017-10-11 01:59:59
#>  9 2017-10-11 02:59:59
#> 10 2017-10-11 03:59:59
#> 11 2017-10-11 04:59:59
```

After:

``` r
library(readxl)

tmp <- tempfile()
path <- "https://github.com/tidyverse/readxl/files/2008644/test_case.xlsx"
download.file(path, tmp)

df <- readxl::read_excel(tmp)

df[20:30,]
#> # A tibble: 11 x 1
#>    date_time          
#>    <dttm>             
#>  1 2017-10-10 19:00:00
#>  2 2017-10-10 20:00:00
#>  3 2017-10-10 21:00:00
#>  4 2017-10-10 22:00:00
#>  5 2017-10-10 23:00:00
#>  6 2017-10-11 00:00:00
#>  7 2017-10-11 01:00:00
#>  8 2017-10-11 02:00:00
#>  9 2017-10-11 03:00:00
#> 10 2017-10-11 04:00:00
#> 11 2017-10-11 05:00:00
```
