### PR TITLE
Support installation and loading on windows and solaris

### DIFF
--- a/src/libxls/locale.c
+++ b/src/libxls/locale.c
@@ -32,6 +32,10 @@
 #include <stdlib.h>
 #include "libxls/locale.h"
 
+#ifdef __sun
+#include <string.h>
+#endif
+
 #if defined(__MINGW32__)
   static char* old_locale;
 #endif
@@ -59,6 +63,8 @@ void xls_freelocale(xls_locale_t locale) {
         return;
 #if defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64) || defined(WINDOWS)
     _free_locale(locale);
+#elif defined(__sun)
+   return;
 #else
     freelocale(locale);
 #endif
@@ -71,6 +77,8 @@ size_t xls_wcstombs_l(char *restrict s, const wchar_t *restrict pwcs, size_t n, 
     return _wcstombs_l(s, pwcs, n, loc);
 #elif defined(HAVE_WCSTOMBS_L)
     return wcstombs_l(s, pwcs, n, loc);
+#elif defined(__sun)
+    return wcstombs(s, pwcs, n);
 #else
     locale_t oldlocale = uselocale(loc);
     size_t result = wcstombs(s, pwcs, n);

--- a/src/libxls/locale.c
+++ b/src/libxls/locale.c
@@ -32,27 +32,32 @@
 #include <stdlib.h>
 #include "libxls/locale.h"
 
-#define GCC_VERSION (__GNUC__ * 10000 \
-                     + __GNUC_MINOR__ * 100 \
-                     + __GNUC_PATCHLEVEL__)
+#if defined(__MINGW32__)
+  static char* old_locale;
+#endif
 
 xls_locale_t xls_createlocale() {
-#if defined(__MINGW32__) && GCC_VERSION <= 40903
-    xls_locale_t loc = {0};
-    return loc;
+#if defined(__MINGW32__)
+    old_locale = setlocale(LC_CTYPE, ".65001");
+    return NULL;
 #elif defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64) || defined(WINDOWS)
     return _create_locale(LC_CTYPE, ".65001");
+#elif defined(__sun)
+    return NULL;
 #else
     return newlocale(LC_CTYPE_MASK, "C.UTF-8", NULL);
 #endif
 }
 
 void xls_freelocale(xls_locale_t locale) {
+#if defined(__MINGW32__)
+    setlocale(LC_ALL, old_locale);
+    return;
+#endif
+
     if (!locale)
         return;
-#if defined(__MINGW32__)
-    return;
-#elif defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64) || defined(WINDOWS)
+#if defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64) || defined(WINDOWS)
     _free_locale(locale);
 #else
     freelocale(locale);
@@ -60,7 +65,9 @@ void xls_freelocale(xls_locale_t locale) {
 }
 
 size_t xls_wcstombs_l(char *restrict s, const wchar_t *restrict pwcs, size_t n, xls_locale_t loc) {
-#if defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64) || defined(WINDOWS)
+#if defined(__MINGW32__)
+    return wcstombs(s, pwcs, n);
+#elif defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64) || defined(WINDOWS)
     return _wcstombs_l(s, pwcs, n, loc);
 #elif defined(HAVE_WCSTOMBS_L)
     return wcstombs_l(s, pwcs, n, loc);

--- a/src/libxls/locale.h
+++ b/src/libxls/locale.h
@@ -36,7 +36,9 @@
 #if defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64) || defined(WINDOWS)
 typedef _locale_t xls_locale_t;
 #elif defined(__sun)
-typedef char* xls_locale_t;
+/* we never actually use the only variable declared with this type on solaris,
+ * so its precise type doesn't really matter */
+typedef void* xls_locale_t;
 #else
 typedef locale_t xls_locale_t;
 #endif

--- a/src/libxls/locale.h
+++ b/src/libxls/locale.h
@@ -35,6 +35,8 @@
 
 #if defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64) || defined(WINDOWS)
 typedef _locale_t xls_locale_t;
+#elif defined(__sun)
+typedef char* xls_locale_t;
 #else
 typedef locale_t xls_locale_t;
 #endif

--- a/src/unix/config-solaris.h
+++ b/src/unix/config-solaris.h
@@ -1,0 +1,109 @@
+/* config.h.  Generated from config.h.in by configure.  */
+/* config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* define if the compiler supports basic C++11 syntax */
+#define HAVE_CXX11 1
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#define HAVE_DLFCN_H 1
+
+/* Define if you have the iconv() function and it works. */
+#define HAVE_ICONV 1
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define to 1 if your system has a GNU libc compatible `malloc' function, and
+   to 0 otherwise. */
+#define HAVE_MALLOC 1
+
+/* Define to 1 if you have the <memory.h> header file. */
+#define HAVE_MEMORY_H 1
+
+/* Define to 1 if your system has a GNU libc compatible `realloc' function,
+   and to 0 otherwise. */
+#define HAVE_REALLOC 1
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the `strdup' function. */
+#define HAVE_STRDUP 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* Define to 1 if you have the <wchar.h> header file. */
+#define HAVE_WCHAR_H 1
+
+/* Define to 1 if you have the `wcstombs_l' function. */
+/* #undef HAVE_WCSTOMBS_L */
+
+/* Define to 1 if you have the <xlocale.h> header file. */
+/* #undef HAVE_XLOCALE_H */
+
+/* Define as const if the declaration of iconv() needs const. */
+#define ICONV_CONST const
+
+/* Major version */
+#define LIBXLS_MAJOR_VERSION 1
+
+/* Micro version */
+#define LIBXLS_MICRO_VERSION 2
+
+/* Minor version */
+#define LIBXLS_MINOR_VERSION 6
+
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
+#define LT_OBJDIR ".libs/"
+
+/* Name of package */
+#define PACKAGE "libxls"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "https://github.com/libxls/libxls/issues"
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "libxls"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "libxls 1.6.2"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "libxls"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL "https://github.com/libxls/libxls"
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "1.6.2"
+
+/* Define to 1 if you have the ANSI C header files. */
+#define STDC_HEADERS 1
+
+/* Version number of package */
+#define VERSION "1.6.2"
+
+/* Define to rpl_malloc if the replacement function should be used. */
+/* #undef malloc */
+
+/* Define to rpl_realloc if the replacement function should be used. */
+/* #undef realloc */
+
+/* Define to `unsigned int' if <sys/types.h> does not define. */
+/* #undef size_t */

--- a/src/unix/config.h
+++ b/src/unix/config.h
@@ -1,5 +1,7 @@
 #ifdef __APPLE__
 #include "unix/config-macos.h"
+#elif defined(__sun)
+#include "unix/config-solaris.h"
 #else
 #include "unix/config-unix.h"
 #endif


### PR DESCRIPTION
Older versions of the windows C runtime don't have _create_locale, so
instead we use setlocale and the reset it to the previous locale.

On solaris we just do nothing to change the locale.

Fixes #660
Fixes #661