### PR TITLE
Fix compilation on Alpine Linux

### DIFF
--- a/src/SheetView.h
+++ b/src/SheetView.h
@@ -1,6 +1,3 @@
-#include <unistd.h>
-#include <sys/time.h>
-
 #include "CellLimits.h"
 #include "ColSpec.h"
 #include "XlsWorkBook.h"
@@ -15,6 +12,8 @@
 
 #include <algorithm>
 #include <string>
+#include <sys/time.h> // alpine linux / musl
+#include <unistd.h>   // alpine linux / musl
 #include <vector>
 
 class Xls {

--- a/src/SheetView.h
+++ b/src/SheetView.h
@@ -1,3 +1,6 @@
+#include <unistd.h>
+#include <sys/time.h>
+
 #include "CellLimits.h"
 #include "ColSpec.h"
 #include "XlsWorkBook.h"


### PR DESCRIPTION
and other systems that use musl.

The problem is that the internal musl header that defines
`uid_t` and `gid_t` only defines it conditionally, if a macro is set.
This macro is set if the header is included from `unistd.h`,
but not if included from another header.

readxl uses `#pragma once`, so the header will not be included
twice, so `uid_t` might not be defined, if unistd.h is not
included early on.

The same story happens with `struct timeval` and `sys/time.h`.

Closes https://github.com/r-hub/r-minimal/issues/40