### PR TITLE
Rework libxls locale patch

### DIFF
--- a/src/libxls/locale.c
+++ b/src/libxls/locale.c
@@ -34,15 +34,17 @@
 
 #if defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64) || defined(WINDOWS)
 #ifdef __GNUC__
-  // g++ 10 indicates Rtools42 and UCRT
-  #if __GNUC__ < 10
-    #define WINDOWS_BEFORE_RTOOLS_42
-  #endif
+    // Rtools42 | R 4.2 | GCC 10 | UCRT
+    // Rtools40 | R 4.0.x to 4.1.x | GCC 8.3.0 | MSVCRT
+    // Rtools35 | R 3.3.x to 3.6.x | GCC 4.9.3 | MSVCRT
+    #if __GNUC__ < 10
+      #define WINDOWS_BEFORE_RTOOLS_42
+    #endif
 #endif
 #endif
 
 #ifdef WINDOWS_BEFORE_RTOOLS_42
-static char* old_locale;
+    static char* old_locale;
 #endif
 
 xls_locale_t xls_createlocale() {

--- a/src/libxls/locale.c
+++ b/src/libxls/locale.c
@@ -32,8 +32,24 @@
 #include <stdlib.h>
 #include "libxls/locale.h"
 
-xls_locale_t xls_createlocale() {
 #if defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64) || defined(WINDOWS)
+#ifdef __GNUC__
+  // g++ 10 indicates Rtools42 and UCRT
+  #if __GNUC__ < 10
+    #define WINDOWS_BEFORE_RTOOLS_42
+  #endif
+#endif
+#endif
+
+#ifdef WINDOWS_BEFORE_RTOOLS_42
+static char* old_locale;
+#endif
+
+xls_locale_t xls_createlocale() {
+#if defined(WINDOWS_BEFORE_RTOOLS_42)
+    old_locale = setlocale(LC_CTYPE, ".65001");
+    return NULL;
+#elif defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64) || defined(WINDOWS)
     return _create_locale(LC_CTYPE, ".65001");
 #else
     return newlocale(LC_CTYPE_MASK, "C.UTF-8", NULL);
@@ -41,6 +57,11 @@ xls_locale_t xls_createlocale() {
 }
 
 void xls_freelocale(xls_locale_t locale) {
+#if defined(WINDOWS_BEFORE_RTOOLS_42)
+    setlocale(LC_ALL, old_locale);
+    return;
+#endif
+
     if (!locale)
         return;
 #if defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64) || defined(WINDOWS)
@@ -51,7 +72,9 @@ void xls_freelocale(xls_locale_t locale) {
 }
 
 size_t xls_wcstombs_l(char *restrict s, const wchar_t *restrict pwcs, size_t n, xls_locale_t loc) {
-#if defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64) || defined(WINDOWS)
+#if defined(WINDOWS_BEFORE_RTOOLS_42)
+    return wcstombs(s, pwcs, n);
+#elif defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64) || defined(WINDOWS)
     return _wcstombs_l(s, pwcs, n, loc);
 #elif defined(HAVE_WCSTOMBS_L)
     return wcstombs_l(s, pwcs, n, loc);

--- a/src/libxls/locale.c
+++ b/src/libxls/locale.c
@@ -60,7 +60,7 @@ xls_locale_t xls_createlocale() {
 
 void xls_freelocale(xls_locale_t locale) {
 #if defined(WINDOWS_BEFORE_RTOOLS_42)
-    setlocale(LC_ALL, old_locale);
+    setlocale(LC_CTYPE, old_locale);
     return;
 #endif
 

--- a/src/libxls/locale.c
+++ b/src/libxls/locale.c
@@ -37,18 +37,18 @@
     // Rtools42 | R 4.2 | GCC 10 | UCRT
     // Rtools40 | R 4.0.x to 4.1.x | GCC 8.3.0 | MSVCRT
     // Rtools35 | R 3.3.x to 3.6.x | GCC 4.9.3 | MSVCRT
-    #if __GNUC__ < 10
-      #define WINDOWS_BEFORE_RTOOLS_42
+    #if __GNUC__ < 8
+      #define WINDOWS_BEFORE_RTOOLS_40
     #endif
 #endif
 #endif
 
-#ifdef WINDOWS_BEFORE_RTOOLS_42
+#ifdef WINDOWS_BEFORE_RTOOLS_40
     static char* old_locale;
 #endif
 
 xls_locale_t xls_createlocale() {
-#if defined(WINDOWS_BEFORE_RTOOLS_42)
+#if defined(WINDOWS_BEFORE_RTOOLS_40)
     old_locale = setlocale(LC_CTYPE, ".65001");
     return NULL;
 #elif defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64) || defined(WINDOWS)
@@ -59,7 +59,7 @@ xls_locale_t xls_createlocale() {
 }
 
 void xls_freelocale(xls_locale_t locale) {
-#if defined(WINDOWS_BEFORE_RTOOLS_42)
+#if defined(WINDOWS_BEFORE_RTOOLS_40)
     setlocale(LC_CTYPE, old_locale);
     return;
 #endif
@@ -74,7 +74,7 @@ void xls_freelocale(xls_locale_t locale) {
 }
 
 size_t xls_wcstombs_l(char *restrict s, const wchar_t *restrict pwcs, size_t n, xls_locale_t loc) {
-#if defined(WINDOWS_BEFORE_RTOOLS_42)
+#if defined(WINDOWS_BEFORE_RTOOLS_40)
     return wcstombs(s, pwcs, n);
 #elif defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64) || defined(WINDOWS)
     return _wcstombs_l(s, pwcs, n, loc);

--- a/src/libxls/locale.c
+++ b/src/libxls/locale.c
@@ -32,53 +32,29 @@
 #include <stdlib.h>
 #include "libxls/locale.h"
 
-#ifdef __sun
-#include <string.h>
-#endif
-
-#if defined(__MINGW32__)
-  static char* old_locale;
-#endif
-
 xls_locale_t xls_createlocale() {
-#if defined(__MINGW32__)
-    old_locale = setlocale(LC_CTYPE, ".65001");
-    return NULL;
-#elif defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64) || defined(WINDOWS)
+#if defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64) || defined(WINDOWS)
     return _create_locale(LC_CTYPE, ".65001");
-#elif defined(__sun)
-    return NULL;
 #else
     return newlocale(LC_CTYPE_MASK, "C.UTF-8", NULL);
 #endif
 }
 
 void xls_freelocale(xls_locale_t locale) {
-#if defined(__MINGW32__)
-    setlocale(LC_ALL, old_locale);
-    return;
-#endif
-
     if (!locale)
         return;
 #if defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64) || defined(WINDOWS)
     _free_locale(locale);
-#elif defined(__sun)
-   return;
 #else
     freelocale(locale);
 #endif
 }
 
 size_t xls_wcstombs_l(char *restrict s, const wchar_t *restrict pwcs, size_t n, xls_locale_t loc) {
-#if defined(__MINGW32__)
-    return wcstombs(s, pwcs, n);
-#elif defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64) || defined(WINDOWS)
+#if defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64) || defined(WINDOWS)
     return _wcstombs_l(s, pwcs, n, loc);
 #elif defined(HAVE_WCSTOMBS_L)
     return wcstombs_l(s, pwcs, n, loc);
-#elif defined(__sun)
-    return wcstombs(s, pwcs, n);
 #else
     locale_t oldlocale = uselocale(loc);
     size_t result = wcstombs(s, pwcs, n);

--- a/src/libxls/locale.c
+++ b/src/libxls/locale.c
@@ -37,18 +37,18 @@
     // Rtools42 | R 4.2 | GCC 10 | UCRT
     // Rtools40 | R 4.0.x to 4.1.x | GCC 8.3.0 | MSVCRT
     // Rtools35 | R 3.3.x to 3.6.x | GCC 4.9.3 | MSVCRT
-    #if __GNUC__ < 8
-      #define WINDOWS_BEFORE_RTOOLS_40
+    #if __GNUC__ < 10
+      #define WINDOWS_BEFORE_RTOOLS_42
     #endif
 #endif
 #endif
 
-#ifdef WINDOWS_BEFORE_RTOOLS_40
+#ifdef WINDOWS_BEFORE_RTOOLS_42
     static char* old_locale;
 #endif
 
 xls_locale_t xls_createlocale() {
-#if defined(WINDOWS_BEFORE_RTOOLS_40)
+#if defined(WINDOWS_BEFORE_RTOOLS_42)
     old_locale = setlocale(LC_CTYPE, ".65001");
     return NULL;
 #elif defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64) || defined(WINDOWS)
@@ -59,7 +59,7 @@ xls_locale_t xls_createlocale() {
 }
 
 void xls_freelocale(xls_locale_t locale) {
-#if defined(WINDOWS_BEFORE_RTOOLS_40)
+#if defined(WINDOWS_BEFORE_RTOOLS_42)
     setlocale(LC_CTYPE, old_locale);
     return;
 #endif
@@ -74,7 +74,7 @@ void xls_freelocale(xls_locale_t locale) {
 }
 
 size_t xls_wcstombs_l(char *restrict s, const wchar_t *restrict pwcs, size_t n, xls_locale_t loc) {
-#if defined(WINDOWS_BEFORE_RTOOLS_40)
+#if defined(WINDOWS_BEFORE_RTOOLS_42)
     return wcstombs(s, pwcs, n);
 #elif defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64) || defined(WINDOWS)
     return _wcstombs_l(s, pwcs, n, loc);


### PR DESCRIPTION
readxl had a pre-existing patch related to R's Windows toolchain(s), around some locale-handling code introduced in libxls 1.6.2.

Patch was originally applied before Rtools 4.2 and UCRT was on the horizon. Most recently touched in 1430c78a6286851d4b24459cdb9c32f1b12e1bb0.

Recent `check_win_devel()` and CRAN submissions revealed that the patch needed a refresh for R-devel (will become 4.2), though the relevant tests only fail when the system language is set to German or, presumably, other non-English languages.

Main things to note re: where this PR ended up:

* Current patch is applied as narrowly as possible, i.e. only when we detect readxl is being compiled with Rtools 3.5.

* I fixed what I suspect was a pre-existing infelicity, where a set & capture / restore sequence seemed to have a locale category mismatch, i.e. `LC_CTYPE` on the way in, but `LC_ALL` on the way out.