### PR TITLE
Fix compilation on Alpine Linux (redux)

### DIFF
--- a/src/SheetView.h
+++ b/src/SheetView.h
@@ -1,3 +1,6 @@
+#include <sys/time.h> // alpine linux / musl must be before others
+#include <unistd.h>   // alpine linux / musl must be before others
+
 #include "CellLimits.h"
 #include "ColSpec.h"
 #include "XlsWorkBook.h"
@@ -12,8 +15,6 @@
 
 #include <algorithm>
 #include <string>
-#include <sys/time.h> // alpine linux / musl
-#include <unistd.h>   // alpine linux / musl
 #include <vector>
 
 class Xls {


### PR DESCRIPTION
Reverts the break of the fix from https://github.com/tidyverse/readxl/pull/687 in https://github.com/tidyverse/readxl/pull/687/commits/9884b53341e475ec984ebe2ff1182ff1347d06ad

i.e. for compilation on Alpine the two headers need to be first so that the types get defined