### PR TITLE
Use negative or infinite sheet number to select sheet counting from the last

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # readxl (development version)
 
+# readxl 1.5.0
+
+* Sheet number in `read_excel()`, `read_xls()`, and `read_xlsx()` can now be negative or infinite to select the sheet counting from the last one (#742, @DanChaltiel).
+
 # readxl 1.4.3
 
 This release contains no user-facing changes.

--- a/R/read_excel.R
+++ b/R/read_excel.R
@@ -237,9 +237,10 @@ standardise_sheet <- function(sheet, range, sheet_names) {
 
   if (is.numeric(sheet)) {
     if (sheet < 1) {
-      stop("`sheet` must be positive", call. = FALSE)
+      length(sheet_names) + sheet
+    } else {
+      floor(sheet) - 1L
     }
-    floor(sheet) - 1L
   } else if (is.character(sheet)) {
     if (!(sheet %in% sheet_names)) {
       stop("Sheet '", sheet, "' not found", call. = FALSE)

--- a/R/read_excel.R
+++ b/R/read_excel.R
@@ -237,8 +237,10 @@ standardise_sheet <- function(sheet, range, sheet_names) {
 
   if (is.numeric(sheet)) {
     if (sheet < 1) {
+      if(is.infinite(sheet)) sheet <- -length(sheet_names)
       length(sheet_names) + sheet
     } else {
+      if(is.infinite(sheet)) sheet <- length(sheet_names)
       floor(sheet) - 1L
     }
   } else if (is.character(sheet)) {


### PR DESCRIPTION
Hi,

It is quite a natural interface to select the last sheet using a negative integer or infinite, one that I've seen in many packages.

Moreover, as noticed in https://github.com/tidyverse/readxl/issues/710, using `sheet=Inf` plainly makes the R session crash.

This little PR circumvolves this problem. 

Unfortunately, I could not manage to make the compiler work so I only tested that using `assignInNamespace()`.

